### PR TITLE
Copying nested dict when call node.set and node.to_dict

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -13,7 +13,7 @@ jobs:
         -   5672:5672
     strategy:
       matrix:
-        python-version: ['3.9', "3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -13,7 +13,7 @@ jobs:
         -   5672:5672
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/node_graph/node.py
+++ b/node_graph/node.py
@@ -474,7 +474,9 @@ class Node:
             data (dict): _description_
         """
         from node_graph.socket import NodeSocket
+        from node_graph.utils import deep_copy_only_dicts
 
+        data = deep_copy_only_dicts(data)
         for key, value in data.items():
             if key in self.properties.keys():
                 self.properties[key].value = value

--- a/node_graph/node.py
+++ b/node_graph/node.py
@@ -206,6 +206,7 @@ class Node:
         import json
         import hashlib
         import cloudpickle as pickle
+        from node_graph.utils import deep_copy_only_dicts
 
         if short:
             data = {
@@ -260,6 +261,10 @@ class Node:
                 data["metadata"]["hash"] = str(uuid1())
                 # we pickle the class so that we can load again
                 data["node_class"] = pickle.dumps(self.__class__)
+        # to avoid some dict has the same address with others nodes
+        # which happens when {} is used as default value
+        # we copy the value only
+        data = deep_copy_only_dicts(data)
         return data
 
     def get_metadata(self):

--- a/node_graph/utils.py
+++ b/node_graph/utils.py
@@ -10,12 +10,13 @@ def register(pool, entries):
 def get_entries(entry_point_name):
     """Get entries from the entry point."""
     from importlib.metadata import entry_points
+    import sys
 
     pool = {}
     eps = entry_points()
-    try:
+    if sys.version_info >= (3, 10):
         group = eps.select(group=entry_point_name)
-    except ValueError:
+    else:
         # deprecated in 3.10
         eps.get(entry_point_name, [])
     for entry_point in group:

--- a/node_graph/utils.py
+++ b/node_graph/utils.py
@@ -12,7 +12,9 @@ def get_entries(entry_point_name):
     from importlib.metadata import entry_points
 
     pool = {}
-    for entry_point in entry_points().get(entry_point_name, []):
+    eps = entry_points()
+    group = eps.select(group=entry_point_name)
+    for entry_point in group:
         new_entries = entry_point.load()
         register(pool, new_entries)
     return pool
@@ -61,3 +63,14 @@ def yaml_to_dict(data):
     ntdata["links"] = links
     ntdata.setdefault("ctrl_links", {})
     return ntdata
+
+
+def deep_copy_only_dicts(original):
+    """Copy all nested dictionaries in a structure but keep
+    the immutable values (such as integers, strings, or tuples)
+    shared between the original and the copy"""
+    if isinstance(original, dict):
+        return {k: deep_copy_only_dicts(v) for k, v in original.items()}
+    else:
+        # Return the original value if it's not a dictionary
+        return original

--- a/node_graph/utils.py
+++ b/node_graph/utils.py
@@ -17,8 +17,7 @@ def get_entries(entry_point_name):
     if sys.version_info >= (3, 10):
         group = eps.select(group=entry_point_name)
     else:
-        # deprecated in 3.10
-        eps.get(entry_point_name, [])
+        group = eps.get(entry_point_name, [])
     for entry_point in group:
         new_entries = entry_point.load()
         register(pool, new_entries)

--- a/node_graph/utils.py
+++ b/node_graph/utils.py
@@ -13,7 +13,11 @@ def get_entries(entry_point_name):
 
     pool = {}
     eps = entry_points()
-    group = eps.select(group=entry_point_name)
+    try:
+        group = eps.select(group=entry_point_name)
+    except ValueError:
+        # deprecated in 3.10
+        eps.get(entry_point_name, [])
     for entry_point in group:
         new_entries = entry_point.load()
         register(pool, new_entries)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     ],
     package_data={},
     include_package_data=True,
-    python_requires=">=3.10",
+    python_requires=">=3.9",
     test_suite="setup.test_suite",
 )

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     ],
     package_data={},
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     test_suite="setup.test_suite",
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="node_graph",
-    version="0.0.1",
+    version="0.0.2",
     description="Create node-based workflow",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -49,6 +49,6 @@ setup(
     ],
     package_data={},
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     test_suite="setup.test_suite",
 )


### PR DESCRIPTION
There are many cases a dict could be overridden by other nodes.
- When a dict is used as the inputs of many nodes, in the `node.set` case
- When a dict (mutable) is used as default (which is a common gotcha), in the `node.to_dict` case.

This PR copies the single values and creates a new dict.


## Fix
Fix depreciated entry point.
