### PR TITLE
Decorators return the wrapper, add socket operation and graph manager

### DIFF
--- a/src/node_graph/collection.py
+++ b/src/node_graph/collection.py
@@ -57,10 +57,10 @@ def get_item_class(
             raise Exception(
                 f"Identifier {identifier} is not a valid {base_class.__name__} class or entry point."
             )
-    elif isinstance(getattr(identifier, "NodeCls", None), type) and issubclass(
-        identifier.NodeCls, base_class
+    elif isinstance(getattr(identifier, "_NodeCls", None), type) and issubclass(
+        identifier._NodeCls, base_class
     ):
-        ItemClass = identifier.NodeCls
+        ItemClass = identifier._NodeCls
     else:
         raise Exception(
             f"Identifier {identifier} is not a valid {base_class.__name__} class or entry point."

--- a/src/node_graph/link.py
+++ b/src/node_graph/link.py
@@ -71,10 +71,10 @@ class NodeLink:
         i = 0
         for link in self.from_socket._links:
             if (
-                link.from_node == self.from_node
-                and link.from_socket == self.from_socket
-                and link.to_node == self.to_node
-                and link.to_socket == self.to_socket
+                link.from_node.name == self.from_node.name
+                and link.from_socket._name == self.from_socket._name
+                and link.to_node.name == self.to_node.name
+                and link.to_socket._name == self.to_socket._name
             ):
                 break
             i += 1
@@ -83,10 +83,10 @@ class NodeLink:
         i = 0
         for link in self.to_socket._links:
             if (
-                link.from_node == self.from_node
-                and link.from_socket == self.from_socket
-                and link.to_node == self.to_node
-                and link.to_socket == self.to_socket
+                link.from_node.name == self.from_node.name
+                and link.from_socket._name == self.from_socket._name
+                and link.to_node.name == self.to_node.name
+                and link.to_socket._name == self.to_socket._name
             ):
                 break
             i += 1

--- a/src/node_graph/manager.py
+++ b/src/node_graph/manager.py
@@ -1,0 +1,82 @@
+"""
+Simple global variable approach.
+Note pitfalls:
+    - lack of concurrency control
+    - collisions in library code
+    - difficulty testing in isolation
+    - etc.
+"""
+from contextlib import contextmanager
+
+
+class CurrentGraphManager:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Enforce the singleton pattern. Only one instance of
+        CurrentGraphManager is created for the entire process.
+        """
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._graph = None  # Storage for the active graph
+        return cls._instance
+
+    def get_current_graph(self):
+        """
+        Retrieve the current graph, or create a new one if none is set.
+        """
+        from node_graph.node_graph import NodeGraph
+
+        if self._graph is None:
+            self._graph = NodeGraph()
+        return self._graph
+
+    def set_current_graph(self, graph):
+        """
+        Set the active graph to the given instance.
+        """
+        self._graph = graph
+
+    @contextmanager
+    def active_graph(self, graph):
+        """
+        Context manager that temporarily overrides the current graph
+        with `graph`, restoring the old graph when exiting the context.
+        """
+        old_graph = self._graph
+        self._graph = graph
+        try:
+            yield graph
+        finally:
+            self._graph = old_graph
+
+
+# Create a global manager instance
+_manager = CurrentGraphManager()
+
+
+def get_current_graph():
+    """
+    Helper function to retrieve the graph
+    through the global manager instance.
+    """
+    return _manager.get_current_graph()
+
+
+def set_current_graph(graph):
+    """
+    Helper function to set the graph through the
+    global manager instance.
+    """
+    _manager.set_current_graph(graph)
+
+
+@contextmanager
+def active_graph(graph):
+    """
+    Top-level context manager that defers to
+    the manager's `active_graph` method.
+    """
+    with _manager.active_graph(graph) as g:
+        yield g

--- a/src/node_graph/node.py
+++ b/src/node_graph/node.py
@@ -353,6 +353,26 @@ class Node:
         """Get the default executor."""
         return self._executor
 
+    def execute(self):
+        """Execute the node."""
+        executor = NodeExecutor(**self.get_executor()).executor
+        # the imported executor could be a wrapped function
+        if hasattr(executor, "_NodeCls") and hasattr(executor, "_func"):
+            executor = getattr(executor, "_func")
+        inputs = self.inputs._value
+        args = [inputs[arg] for arg in self.args_data["args"]]
+        kwargs = {key: inputs[key] for key in self.args_data["kwargs"]}
+        var_kwargs = (
+            inputs[self.args_data["var_kwargs"]]
+            if self.args_data["var_kwargs"]
+            else None
+        )
+        if var_kwargs is None:
+            result = executor(*args, **kwargs)
+        else:
+            result = executor(*args, **kwargs, **var_kwargs)
+        return result
+
     def get_results(self) -> None:
         """Item data from database"""
 

--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -101,7 +101,10 @@ class NodeGraph:
             identifier = NodeGraphNodeFactory.create_node(identifier)
         # build the task on the fly if the identifier is a callable
         elif callable(identifier):
-            identifier = build_node_from_callable(identifier)
+            if hasattr(identifier, "_NodeCls"):
+                identifier = identifier._NodeCls
+            else:
+                identifier = build_node_from_callable(identifier)
         node = self.nodes._new(identifier, name, **kwargs)
         self._version += 1
         return node

--- a/src/node_graph/nodes/factory/function_node.py
+++ b/src/node_graph/nodes/factory/function_node.py
@@ -71,6 +71,7 @@ class DecoratedFunctionNodeFactory(BaseNodeFactory):
         tdata["executor"] = NodeExecutor.from_callable(func).to_dict()
         if node_class:
             tdata["metadata"]["node_class"] = node_class
+        tdata["default_name"] = func.__name__
         additional_data = additional_data or {}
         tdata.update(additional_data)
 

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -37,26 +37,6 @@ def op_floordiv(x, y):
     return x // y
 
 
-def op_and(x, y):
-    return x & y
-
-
-def op_or(x, y):
-    return x | y
-
-
-def op_xor(x, y):
-    return x ^ y
-
-
-def op_lshift(x, y):
-    return x << y
-
-
-def op_rshift(x, y):
-    return x >> y
-
-
 # comparison operations
 def op_lt(x, y):
     return x < y
@@ -168,38 +148,6 @@ class OperatorSocketMixin:
 
     def __ne__(self, other):
         return self._create_operator_node(op_ne, other)
-
-    # Bitwise Operations
-    def __and__(self, other):
-        return self._create_operator_node(op_and, other)
-
-    def __or__(self, other):
-        return self._create_operator_node(op_or, other)
-
-    def __xor__(self, other):
-        return self._create_operator_node(op_xor, other)
-
-    def __lshift__(self, other):
-        return self._create_operator_node(op_lshift, other)
-
-    def __rshift__(self, other):
-        return self._create_operator_node(op_rshift, other)
-
-    # Reverse Bitwise Operations
-    def __rand__(self, other):
-        return self._create_operator_node(op_and, other)
-
-    def __ror__(self, other):
-        return self._create_operator_node(op_or, other)
-
-    def __rxor__(self, other):
-        return self._create_operator_node(op_xor, other)
-
-    def __rlshift__(self, other):
-        return self._create_operator_node(op_lshift, other)
-
-    def __rrshift__(self, other):
-        return self._create_operator_node(op_rshift, other)
 
 
 class BaseSocket:

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -69,7 +69,7 @@ class OperatorSocketMixin:
 
         return node
 
-    def _create_operator_node(self, op_func, other):
+    def _create_operator_node(self, op_func, x, y):
         """Create a "hidden" operator Node in the WorkGraph,
         hooking `self` up as 'x' and `other` as 'y'.
         Return the output socket from that new Node.
@@ -81,73 +81,73 @@ class OperatorSocketMixin:
 
         new_node = graph.nodes._new(
             self._decorator()(op_func)._NodeCls,
-            x=self,
-            y=other,
+            x=x,
+            y=y,
         )
         return new_node.outputs.result
 
     # Arithmetic Operations
     def __add__(self, other):
-        return self._create_operator_node(op_add, other)
+        return self._create_operator_node(op_add, self, other)
 
     def __sub__(self, other):
-        return self._create_operator_node(op_sub, other)
+        return self._create_operator_node(op_sub, self, other)
 
     def __mul__(self, other):
-        return self._create_operator_node(op_mul, other)
+        return self._create_operator_node(op_mul, self, other)
 
     def __truediv__(self, other):
-        return self._create_operator_node(op_truediv, other)
+        return self._create_operator_node(op_truediv, self, other)
 
     def __floordiv__(self, other):
-        return self._create_operator_node(op_floordiv, other)
+        return self._create_operator_node(op_floordiv, self, other)
 
     def __mod__(self, other):
-        return self._create_operator_node(op_mod, other)
+        return self._create_operator_node(op_mod, self, other)
 
     def __pow__(self, other):
-        return self._create_operator_node(op_pow, other)
+        return self._create_operator_node(op_pow, self, other)
 
     # Reverse Arithmetic Operations
     def __radd__(self, other):
-        return self._create_operator_node(op_add, other)
+        return self._create_operator_node(op_add, other, self)
 
     def __rsub__(self, other):
-        return self._create_operator_node(op_sub, other)
+        return self._create_operator_node(op_sub, other, self)
 
     def __rmul__(self, other):
-        return self._create_operator_node(op_mul, other)
+        return self._create_operator_node(op_mul, other, self)
 
     def __rtruediv__(self, other):
-        return self._create_operator_node(op_truediv, other)
+        return self._create_operator_node(op_truediv, other, self)
 
     def __rfloordiv__(self, other):
-        return self._create_operator_node(op_floordiv, other)
+        return self._create_operator_node(op_floordiv, other, self)
 
     def __rmod__(self, other):
-        return self._create_operator_node(op_mod, other)
+        return self._create_operator_node(op_mod, other, self)
 
     def __rpow__(self, other):
-        return self._create_operator_node(op_pow, other)
+        return self._create_operator_node(op_pow, other, self)
 
     # Comparison Operations
     def __lt__(self, other):
-        return self._create_operator_node(op_lt, other)
+        return self._create_operator_node(op_lt, self, other)
 
     def __le__(self, other):
-        return self._create_operator_node(op_le, other)
+        return self._create_operator_node(op_le, self, other)
 
     def __gt__(self, other):
-        return self._create_operator_node(op_gt, other)
+        return self._create_operator_node(op_gt, self, other)
 
     def __ge__(self, other):
-        return self._create_operator_node(op_ge, other)
+        return self._create_operator_node(op_ge, self, other)
 
     def __eq__(self, other):
-        return self._create_operator_node(op_eq, other)
+        return self._create_operator_node(op_eq, self, other)
 
     def __ne__(self, other):
-        return self._create_operator_node(op_ne, other)
+        return self._create_operator_node(op_ne, self, other)
 
 
 class BaseSocket:

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -4,10 +4,197 @@ from node_graph.property import NodeProperty
 from typing import List, Optional, Dict, Any, TYPE_CHECKING, Union
 from node_graph.collection import get_item_class, EntryPointPool
 
-
 if TYPE_CHECKING:
     from node_graph.node import Node
     from node_graph.link import NodeLink
+
+
+def op_add(x, y):
+    return x + y
+
+
+def op_sub(x, y):
+    return x - y
+
+
+def op_mul(x, y):
+    return x * y
+
+
+def op_truediv(x, y):
+    return x / y
+
+
+def op_pow(x, y):
+    return x**y
+
+
+def op_mod(x, y):
+    return x % y
+
+
+def op_floordiv(x, y):
+    return x // y
+
+
+def op_and(x, y):
+    return x & y
+
+
+def op_or(x, y):
+    return x | y
+
+
+def op_xor(x, y):
+    return x ^ y
+
+
+def op_lshift(x, y):
+    return x << y
+
+
+def op_rshift(x, y):
+    return x >> y
+
+
+# comparison operations
+def op_lt(x, y):
+    return x < y
+
+
+def op_gt(x, y):
+    return x > y
+
+
+def op_le(x, y):
+    return x <= y
+
+
+def op_ge(x, y):
+    return x >= y
+
+
+def op_eq(x, y):
+    return x == y
+
+
+def op_ne(x, y):
+    return x != y
+
+
+class OperatorSocketMixin:
+    def _create_operator_node(self, op_func, other):
+        """Create a "hidden" operator Node in the WorkGraph,
+        hooking `self` up as 'x' and `other` as 'y'.
+        Return the output socket from that new Node.
+        """
+        from node_graph.decorator import node
+
+        graph = self._node.parent
+        if not graph:
+            raise ValueError("Socket does not belong to a WorkGraph.")
+
+        new_node = graph.nodes._new(
+            node()(op_func)._NodeCls,
+            x=self,
+            y=other,
+        )
+        return new_node.outputs.result
+
+    # Arithmetic Operations
+    def __add__(self, other):
+        return self._create_operator_node(op_add, other)
+
+    def __sub__(self, other):
+        return self._create_operator_node(op_sub, other)
+
+    def __mul__(self, other):
+        return self._create_operator_node(op_mul, other)
+
+    def __truediv__(self, other):
+        return self._create_operator_node(op_truediv, other)
+
+    def __floordiv__(self, other):
+        return self._create_operator_node(op_floordiv, other)
+
+    def __mod__(self, other):
+        return self._create_operator_node(op_mod, other)
+
+    def __pow__(self, other):
+        return self._create_operator_node(op_pow, other)
+
+    # Reverse Arithmetic Operations
+    def __radd__(self, other):
+        return self._create_operator_node(op_add, other)
+
+    def __rsub__(self, other):
+        return self._create_operator_node(op_sub, other)
+
+    def __rmul__(self, other):
+        return self._create_operator_node(op_mul, other)
+
+    def __rtruediv__(self, other):
+        return self._create_operator_node(op_truediv, other)
+
+    def __rfloordiv__(self, other):
+        return self._create_operator_node(op_floordiv, other)
+
+    def __rmod__(self, other):
+        return self._create_operator_node(op_mod, other)
+
+    def __rpow__(self, other):
+        return self._create_operator_node(op_pow, other)
+
+    # Comparison Operations
+    def __lt__(self, other):
+        return self._create_operator_node(op_lt, other)
+
+    def __le__(self, other):
+        return self._create_operator_node(op_le, other)
+
+    def __gt__(self, other):
+        return self._create_operator_node(op_gt, other)
+
+    def __ge__(self, other):
+        return self._create_operator_node(op_ge, other)
+
+    def __eq__(self, other):
+        return self._create_operator_node(op_eq, other)
+
+    def __ne__(self, other):
+        return self._create_operator_node(op_ne, other)
+
+    # Bitwise Operations
+    def __and__(self, other):
+        return self._create_operator_node(op_and, other)
+
+    def __or__(self, other):
+        return self._create_operator_node(op_or, other)
+
+    def __xor__(self, other):
+        return self._create_operator_node(op_xor, other)
+
+    def __lshift__(self, other):
+        return self._create_operator_node(op_lshift, other)
+
+    def __rshift__(self, other):
+        return self._create_operator_node(op_rshift, other)
+
+    # Reverse Bitwise Operations
+    def __rand__(self, other):
+        return self._create_operator_node(op_and, other)
+
+    def __ror__(self, other):
+        return self._create_operator_node(op_or, other)
+
+    def __rxor__(self, other):
+        return self._create_operator_node(op_xor, other)
+
+    def __rlshift__(self, other):
+        return self._create_operator_node(op_lshift, other)
+
+    def __rrshift__(self, other):
+        return self._create_operator_node(op_rshift, other)
 
 
 class BaseSocket:
@@ -94,7 +281,7 @@ class BaseSocket:
         return data
 
 
-class NodeSocket(BaseSocket):
+class NodeSocket(BaseSocket, OperatorSocketMixin):
 
     _identifier: str = "NodeSocket"
 

--- a/tests/debug_tests.py
+++ b/tests/debug_tests.py
@@ -5,31 +5,21 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
-def get_pytest_args():
-    """Extract pytest arguments from command-line arguments."""
-    try:
-        # Find where "--" appears in the args (separates args from pytest args)
-        index = sys.argv.index("--")
-        return sys.argv[index + 1 :]  # Extract pytest arguments
-    except ValueError:
-        logging.warning(
-            "No `--` separator found. Running pytest with default arguments."
-        )
-        return []
-
-
 def main():
-    """Run pytest and exit with the correct status code."""
-    pytest_args = get_pytest_args()
+    """Run pytest."""
+    pytest_args = [
+        "tests/test_socket.py::test_operation[lt-op_lt-False]",
+        "-sv",  # Show output and verbose mode
+    ]
 
     logging.info(f"Running tests with arguments: {pytest_args}")
 
     # Run pytest with extracted arguments
     result = pytest.main(pytest_args)
 
-    if result.value != 0:
-        logging.error(f"Tests failed with exit code: {result.value}")
-        sys.exit(result.value)
+    if result != 0:  # `pytest.main()` directly returns an integer exit code
+        logging.error(f"Tests failed with exit code: {result}")
+        sys.exit(result)
     else:
         logging.info("All tests passed successfully.")
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,9 +1,11 @@
+import pytest
+from node_graph.collection import Collection
+from node_graph.node import Node
+from node_graph import NodeGraph
+
+
 def test_base_collection():
     """Test base collection."""
-    from node_graph.collection import Collection
-    from node_graph.node import Node
-    from node_graph import NodeGraph
-
     ng = NodeGraph(name="test_base_collection")
     coll = Collection(parent=ng)
     coll.path = "builtins"
@@ -26,3 +28,16 @@ def test_base_collection():
     assert coll._get_by_uuid(node2.uuid) == node2
     # __repr__
     assert repr(coll) == "Collection()\n"
+
+
+def test_delete_items():
+    coll = Collection()
+    coll._items = {"a": 1, "b": 2, "c": 3, "d": 4}
+    del coll[0]
+    assert coll._items == {"b": 2, "c": 3, "d": 4}
+    del coll[[1, 2]]
+    assert coll._items == {"b": 2}
+    with pytest.raises(ValueError, match="Invalid index type for __delitem__: "):
+        del coll[sum]
+    coll._pop(0)
+    assert coll._items == {}

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_link_another_node_graph(ng, ng_decorator):
     """Test link between two node_graph."""
     try:
@@ -25,3 +28,12 @@ def test_clear(ng):
 def test_repr(ng):
     """Test __repr__ method."""
     assert repr(ng.links) == "LinkCollection({} links)\n".format(len(ng.links))
+
+
+def test_delete_link(ng):
+    """Test delete node."""
+    nlink = len(ng.links)
+    del ng.links[[0, 1]]
+    assert len(ng.links) == nlink - 2
+    with pytest.raises(ValueError, match="Invalid index type for __delitem__: "):
+        del ng.links[sum]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,15 @@
+from node_graph.manager import active_graph, get_current_graph, set_current_graph
+from node_graph import NodeGraph
+
+
+def test_manager():
+
+    ng1 = NodeGraph("ng1")
+    set_current_graph(ng1)
+    assert get_current_graph() == ng1
+    with active_graph(NodeGraph("ng2")) as ng2:
+        assert ng1.uuid != ng2.uuid
+        assert get_current_graph() == ng2
+        with active_graph(NodeGraph("ng3")) as ng3:
+            assert get_current_graph() == ng3
+        assert get_current_graph() == ng2

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -156,3 +156,8 @@ def test_nodegraph_node():
         "add2._outputs",
         "add2.result",
     }
+
+
+def test_execute(decorated_myadd):
+    result = decorated_myadd(1, 2)
+    result = result._node.execute()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -2,7 +2,9 @@ import pytest
 import numpy as np
 from node_graph import NodeGraph
 from node_graph.node import Node
+from node_graph.socket import BaseSocket
 from node_graph.nodes import NodePool
+import operator as op
 
 
 def test_check_identifier():
@@ -241,3 +243,30 @@ def test_keys_order():
     assert node.inputs._get_keys() == ["e", "c", "b"]
     del node.inputs[[0, 2]]
     assert node.inputs._get_keys() == ["c"]
+
+
+@pytest.mark.parametrize(
+    "op, name",
+    (
+        (op.add, "op_add"),
+        (op.sub, "op_sub"),
+        (op.mul, "op_mul"),
+        (op.truediv, "op_truediv"),
+        (op.floordiv, "op_floordiv"),
+        (op.mod, "op_mod"),
+        (op.pow, "op_pow"),
+        (op.lshift, "op_lshift"),
+        (op.rshift, "op_rshift"),
+        (op.and_, "op_and"),
+        (op.or_, "op_or"),
+        (op.xor, "op_xor"),
+    ),
+)
+def test_operation(op, name, decorated_myadd):
+    """Test base type socket.
+    Should raise a error when the input data is not
+    the same type as the socket."""
+
+    result = op(decorated_myadd(1, 2), decorated_myadd(1, 2))
+    assert isinstance(result, BaseSocket)
+    assert name in result._node.name

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from node_graph import NodeGraph
 from node_graph.node import Node
-from node_graph.socket import BaseSocket
+from node_graph.socket import BaseSocket, NodeSocketNamespace
 from node_graph.nodes import NodePool
 import operator as op
 
@@ -266,7 +266,17 @@ def test_operation(op, name, decorated_myadd):
     """Test base type socket.
     Should raise a error when the input data is not
     the same type as the socket."""
-
-    result = op(decorated_myadd(1, 2), decorated_myadd(1, 2))
+    socket1 = decorated_myadd(1, 2)
+    socket2 = decorated_myadd(1, 2)
+    print("socket1", socket1)
+    result = op(socket1, socket2)
     assert isinstance(result, BaseSocket)
     assert name in result._node.name
+
+
+def test_unpacking():
+    s = NodeSocketNamespace("test", metadata={"dynamic": True})
+    s._value = {"a": 1, "b": 2}
+    a, b = s
+    assert a.value == 1
+    assert b.value == 2

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -255,18 +255,10 @@ def test_keys_order():
         (op.floordiv, "op_floordiv", 2),
         (op.mod, "op_mod", 0),
         (op.pow, "op_pow", 16),
-        (op.lt, "op_lt", False),
-        (op.gt, "op_gt", True),
-        (op.le, "op_le", False),
-        (op.ge, "op_ge", True),
-        (op.eq, "op_eq", False),
-        (op.ne, "op_ne", True),
     ),
 )
 def test_operation(op, name, ref_result, decorated_myadd):
-    """Test base type socket.
-    Should raise a error when the input data is not
-    the same type as the socket."""
+    """Test socket operation."""
     socket1 = decorated_myadd(2, 2)
     socket2 = decorated_myadd(1, 1)
     result = op(socket1, socket2)
@@ -277,7 +269,47 @@ def test_operation(op, name, ref_result, decorated_myadd):
     assert result == ref_result
     # test with non-socket value
     result = op(socket1, 2)
+    result._node.inputs.x.value = 4
+    result = result._node.execute()
+    assert result == ref_result
+    # test reverse operation
+    result = op(4, socket2)
+    result._node.inputs.y.value = 2
+    result = result._node.execute()
+    assert result == ref_result
+
+
+@pytest.mark.parametrize(
+    "op, name, ref_result",
+    (
+        (op.lt, "op_lt", False),
+        (op.gt, "op_gt", True),
+        (op.le, "op_le", False),
+        (op.ge, "op_ge", True),
+        (op.eq, "op_eq", False),
+        (op.ne, "op_ne", True),
+    ),
+)
+def test_operation_comparision(op, name, ref_result, decorated_myadd):
+    """Test socket comparision operation."""
+    socket1 = decorated_myadd(2, 2)
+    socket2 = decorated_myadd(1, 1)
+    result = op(socket1, socket2)
+    assert isinstance(result, BaseSocket)
+    assert name in result._node.name
     result._node.set({"x": 4, "y": 2})
+    result = result._node.execute()
+    assert result == ref_result
+    # test with non-socket value
+    result = op(socket1, 2)
+    result._node.inputs.x.value = 4
+    result = result._node.execute()
+    assert result == ref_result
+    # test reverse operation
+    # note in the comparision operation, there is not reverse operation
+    # so the inputs.x will be always the socket
+    result = op(4, socket2)
+    result._node.inputs.x.value = 2
     result = result._node.execute()
     assert result == ref_result
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -268,7 +268,6 @@ def test_operation(op, name, decorated_myadd):
     the same type as the socket."""
     socket1 = decorated_myadd(1, 2)
     socket2 = decorated_myadd(1, 2)
-    print("socket1", socket1)
     result = op(socket1, socket2)
     assert isinstance(result, BaseSocket)
     assert name in result._node.name

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -246,31 +246,40 @@ def test_keys_order():
 
 
 @pytest.mark.parametrize(
-    "op, name",
+    "op, name, ref_result",
     (
-        (op.add, "op_add"),
-        (op.sub, "op_sub"),
-        (op.mul, "op_mul"),
-        (op.truediv, "op_truediv"),
-        (op.floordiv, "op_floordiv"),
-        (op.mod, "op_mod"),
-        (op.pow, "op_pow"),
-        (op.lshift, "op_lshift"),
-        (op.rshift, "op_rshift"),
-        (op.and_, "op_and"),
-        (op.or_, "op_or"),
-        (op.xor, "op_xor"),
+        (op.add, "op_add", 6),
+        (op.sub, "op_sub", 2),
+        (op.mul, "op_mul", 8),
+        (op.truediv, "op_truediv", 2),
+        (op.floordiv, "op_floordiv", 2),
+        (op.mod, "op_mod", 0),
+        (op.pow, "op_pow", 16),
+        (op.lt, "op_lt", False),
+        (op.gt, "op_gt", True),
+        (op.le, "op_le", False),
+        (op.ge, "op_ge", True),
+        (op.eq, "op_eq", False),
+        (op.ne, "op_ne", True),
     ),
 )
-def test_operation(op, name, decorated_myadd):
+def test_operation(op, name, ref_result, decorated_myadd):
     """Test base type socket.
     Should raise a error when the input data is not
     the same type as the socket."""
-    socket1 = decorated_myadd(1, 2)
-    socket2 = decorated_myadd(1, 2)
+    socket1 = decorated_myadd(2, 2)
+    socket2 = decorated_myadd(1, 1)
     result = op(socket1, socket2)
     assert isinstance(result, BaseSocket)
     assert name in result._node.name
+    result._node.set({"x": 4, "y": 2})
+    result = result._node.execute()
+    assert result == ref_result
+    # test with non-socket value
+    result = op(socket1, 2)
+    result._node.set({"x": 4, "y": 2})
+    result = result._node.execute()
+    assert result == ref_result
 
 
 def test_unpacking():


### PR DESCRIPTION
## Refactor decorators to return the wrapper instead of executing the function.
-  when called, adds a node to the current graph and returns the outputs.
- input argument mapping from `*args, **kwargs` to node inputs.
- handling of single vs. multiple outputs.

## Add manager
- automatic node instantiation in the active graph.
 

## Implemented operator overloading for Socket to support:
- Arithmetic: +, -, *, /, //, %, **
- Comparison: <, >, <=, >=, ==, !=
- Socket has `_create_operator_task` method to generate implicit nodes for operations.


