### PR TITLE
Override __setattr__ and __getattr__ methods

### DIFF
--- a/src/node_graph/link.py
+++ b/src/node_graph/link.py
@@ -29,12 +29,12 @@ class NodeLink:
 
     def check_socket_match(self) -> None:
         """Check if the socket type match, and belong to the same node graph."""
-        if self.from_node.parent != self.to_node.parent:
+        if self.from_node.graph != self.to_node.graph:
             raise Exception(
                 "Can not link sockets from different {}. {} and {}".format(
-                    self.from_node.parent.__class__.__name__,
-                    self.from_node.parent,
-                    self.to_node.parent,
+                    self.from_node.graph.__class__.__name__,
+                    self.from_node.graph,
+                    self.to_node.graph,
                 )
             )
 

--- a/src/node_graph/node.py
+++ b/src/node_graph/node.py
@@ -17,7 +17,7 @@ class Node:
     Attributes:
         identifier (str): The identifier is used for loading the Node.
         node_type (str): Type of this node. Possible values are "Normal", "REF", "GROUP".
-        parent_uuid (str): UUID of the node graph this node belongs to.
+        graph_uuid (str): UUID of the node graph this node belongs to.
 
     Examples:
         Add nodes:
@@ -42,7 +42,7 @@ class Node:
     identifier: str = "Node"
     default_name: str = None
     node_type: str = "Normal"
-    parent_uuid: str = ""
+    graph_uuid: str = ""
     catalog: str = "Node"
     group_properties: List[List[str]] = None
     group_inputs: List[List[str]] = None
@@ -53,6 +53,7 @@ class Node:
         self,
         name: Optional[str] = None,
         uuid: Optional[str] = None,
+        graph: Optional[Any] = None,
         parent: Optional[Any] = None,
         metadata: Optional[Dict[str, Any]] = None,
         executor: Optional[NodeExecutor] = None,
@@ -62,10 +63,11 @@ class Node:
         Args:
             name (str, optional): Name of the node. Defaults to None.
             uuid (str, optional): UUID of the node. Defaults to None.
-            parent (Any, optional): Parent node. Defaults to None.
+            graph (Any, optional): The node graph this node belongs to. Defaults to None.
         """
         self.name = name or self.identifier
         self.uuid = uuid or str(uuid1())
+        self.graph = graph
         self.parent = parent
         self._metadata = metadata or {}
         self._executor = executor
@@ -178,7 +180,7 @@ class Node:
             {
                 "node_type": self.node_type,
                 "catalog": self.catalog,
-                "parent_uuid": self.parent.uuid if self.parent else self.parent_uuid,
+                "graph_uuid": self.graph.uuid if self.graph else self.graph_uuid,
                 "group_properties": self.group_properties
                 if self.group_properties
                 else [],
@@ -277,7 +279,7 @@ class Node:
         # read all the metadata
         for key in [
             "parent",
-            "parent_uuid",
+            "graph_uuid",
         ]:
             if data["metadata"].get(key):
                 setattr(self, key, data["metadata"].get(key))
@@ -317,29 +319,29 @@ class Node:
     def copy(
         self,
         name: Optional[str] = None,
-        parent: Optional[Any] = None,
+        graph: Optional[Any] = None,
     ) -> Any:
         """Copy a node.
 
-        Copy a node to a new node. If parent is None, the node will be copied inside the same parent,
-        otherwise the node will be copied to a new parent.
+        Copy a node to a new node. If graph is None, the node will be copied inside the same graph,
+        otherwise the node will be copied to a new graph.
         The properties, inputs and outputs will be copied.
 
         Args:
             name (str, optional): _description_. Defaults to None.
-            parent (NodeGraph, optional): _description_. Defaults to None.
+            graph (NodeGraph, optional): _description_. Defaults to None.
 
         Returns:
             Node: _description_
         """
-        if parent is not None:
-            # copy node to a new parent, keep the name
+        if graph is not None:
+            # copy node to a new graph, keep the name
             name = self.name if name is None else name
         else:
-            # copy node inside the same parent, change the name
-            parent = self.parent
+            # copy node inside the same graph, change the name
+            graph = self.graph
             name = f"{self.name}_copy" if name is None else name
-        node = self.__class__(name=name, uuid=None, parent=parent)
+        node = self.__class__(name=name, uuid=None, graph=graph)
         # becareful when copy the properties, the value should be copied
         # it will update the sockets, so we copy the properties first
         # then overwrite the sockets
@@ -401,7 +403,7 @@ class Node:
         for key, value in data.items():
             # if the value is a node, link the node's top-level output to the input
             if isinstance(value, Node):
-                self.parent.add_link(value.outputs["_outputs"], self.inputs[key])
+                self.graph.add_link(value.outputs["_outputs"], self.inputs[key])
                 continue
             if key in self.properties:
                 self.properties[key].value = value

--- a/src/node_graph/node.py
+++ b/src/node_graph/node.py
@@ -73,10 +73,10 @@ class Node:
         self._executor = executor
         self.properties = self.PropertyCollectionClass(self, pool=self.PropertyPool)
         self.inputs = self.InputCollectionClass(
-            "inputs", node=self, pool=self.SocketPool
+            "inputs", node=self, pool=self.SocketPool, graph=self.graph
         )
         self.outputs = self.OutputCollectionClass(
-            "outputs", node=self, pool=self.SocketPool
+            "outputs", node=self, pool=self.SocketPool, graph=self.graph
         )
         self.state = "CREATED"
         self.action = "NONE"

--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -308,7 +308,7 @@ class NodeGraph:
         """
         name = f"{self.name}_copy" if name is None else name
         ng = self.__class__(name=name, uuid=None)
-        ng.nodes = self.nodes._copy(parent=ng)
+        ng.nodes = self.nodes._copy(graph=ng)
         for link in self.links:
             ng.add_link(
                 ng.nodes[link.from_node.name].outputs[link.from_socket._scoped_name],
@@ -336,14 +336,14 @@ class NodeGraph:
         """
         ng: "NodeGraph" = self.__class__(name=name, uuid=None)
         for node_name in node_list:
-            ng.append_node(self.nodes[node_name].copy(parent=ng))
+            ng.append_node(self.nodes[node_name].copy(graph=ng))
         for link in self.links:
             if (
                 add_ref
                 and link.from_node.name not in ng.get_node_names()
                 and link.to_node.name in ng.get_node_names()
             ):
-                ng.append_node(self.nodes[link.from_node.name].copy(parent=ng))
+                ng.append_node(self.nodes[link.from_node.name].copy(graph=ng))
             if (
                 link.from_node.name in ng.get_node_names()
                 and link.to_node.name in ng.get_node_names()
@@ -381,7 +381,7 @@ class NodeGraph:
         Returns:
             NodeGraph: The combined node graph.
         """
-        self.nodes._extend(other.nodes._copy(parent=self))
+        self.nodes._extend(other.nodes._copy(graph=self))
         for link in other.links:
             self.add_link(
                 self.nodes[link.from_node.name].outputs[link.from_socket._name],

--- a/src/node_graph/nodes/factory/base.py
+++ b/src/node_graph/nodes/factory/base.py
@@ -54,13 +54,13 @@ class BaseNodeFactory:
                     self._ndata.get("inputs", {}),
                     node=self,
                     pool=BaseClass.SocketPool,
-                    graph=self.parent,
+                    graph=self.graph,
                 )
                 self.outputs = BaseClass.OutputCollectionClass._from_dict(
                     self._ndata.get("outputs", {}),
                     node=self,
                     pool=BaseClass.SocketPool,
-                    graph=self.parent,
+                    graph=self.graph,
                 )
 
             def get_executor(self):

--- a/src/node_graph/nodes/factory/base.py
+++ b/src/node_graph/nodes/factory/base.py
@@ -51,10 +51,16 @@ class BaseNodeFactory:
 
             def create_sockets(self):
                 self.inputs = BaseClass.InputCollectionClass._from_dict(
-                    self._ndata.get("inputs", {}), node=self, pool=BaseClass.SocketPool
+                    self._ndata.get("inputs", {}),
+                    node=self,
+                    pool=BaseClass.SocketPool,
+                    graph=self.parent,
                 )
                 self.outputs = BaseClass.OutputCollectionClass._from_dict(
-                    self._ndata.get("outputs", {}), node=self, pool=BaseClass.SocketPool
+                    self._ndata.get("outputs", {}),
+                    node=self,
+                    pool=BaseClass.SocketPool,
+                    graph=self.parent,
                 )
 
             def get_executor(self):

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -544,6 +544,7 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
             )
         else:
             ItemClass = get_item_class(identifier, self._SocketPool, BaseSocket)
+            kwargs.pop("graph", None)
             item = ItemClass(
                 name,
                 node=self._node,
@@ -641,6 +642,7 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
             metadata=data.get("metadata", {}),
             node=node,
             parent=parent,
+            graph=kwargs.pop("graph", None),
             pool=pool,
             **kwargs,
         )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,5 +1,5 @@
 import pytest
-from node_graph.collection import Collection
+from node_graph.collection import NodeCollection, Collection
 from node_graph.node import Node
 from node_graph import NodeGraph
 
@@ -7,7 +7,7 @@ from node_graph import NodeGraph
 def test_base_collection():
     """Test base collection."""
     ng = NodeGraph(name="test_base_collection")
-    coll = Collection(parent=ng)
+    coll = NodeCollection(graph=ng)
     coll.path = "builtins"
     node1 = Node(name="node1")
     node2 = Node(name="node2")
@@ -15,7 +15,7 @@ def test_base_collection():
     coll._append(node1)
     coll._append(node2)
     assert len(coll) == 2
-    assert node1.parent == ng
+    assert node1.graph == ng
     # copy
     coll1 = coll._copy()
     assert len(coll1) == 2
@@ -27,7 +27,10 @@ def test_base_collection():
     # get by uuid
     assert coll._get_by_uuid(node2.uuid) == node2
     # __repr__
-    assert repr(coll) == "Collection()\n"
+    assert (
+        repr(coll)
+        == """NodeCollection(parent = "test_base_collection", nodes = ["node2"])"""
+    )
 
 
 def test_delete_items():

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -27,7 +27,7 @@ def test_get_current_graph():
 def test_set_current_graph(decorated_myadd):
     sum = decorated_myadd(1, 2)
     g = get_current_graph()
-    assert g == sum._node.parent
+    assert g == sum._node.graph
     g2 = NodeGraph()
     set_current_graph(g2)
     assert get_current_graph() == g2

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -10,10 +10,10 @@ def test_base_node():
     n = Node.new(NodePool.node_graph.test_float)
     # added to nodegraph
     ng.append_node(n)
-    assert n.parent == ng
+    assert n.graph == ng
     # copy
     n1 = n.copy(name="n1")
-    assert n1.parent == ng
+    assert n1.graph == ng
     assert n1.name == "n1"
 
 
@@ -84,7 +84,7 @@ def test_copy():
     math1 = math.copy()
     assert math1.properties["t"].value == 5
     assert math1.inputs["x"].property.value == 2
-    assert math1.parent.uuid == ng.uuid
+    assert math1.graph.uuid == ng.uuid
     assert math1.name == f"{math.name}_copy"
     #
     ng.append_node(math1)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -23,10 +23,12 @@ def test_metadata():
     socket = n.add_input(
         "node_graph.any",
         "test",
+        graph=ng,
         metadata={"arg_type": "kwargs", "dynamic": True},
         link_limit=100000,
         property={"default": 1},
     )
+    assert socket._graph == ng
     assert socket._metadata == {"dynamic": True, "arg_type": "kwargs"}
     assert socket._link_limit == 100000
     assert socket.property.default == 1

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -332,7 +332,7 @@ def test_set_socket_value():
 
 def test_set_namespace_attr():
     ng = NodeGraph()
-    n = Node(parent=ng)
+    n = Node(graph=ng)
     s = NodeSocketNamespace("a", node=n, graph=ng, metadata={"dynamic": True})
     # auto create a sub-socket "x"
     s.x = 1

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from node_graph import NodeGraph
 from node_graph.node import Node
-from node_graph.socket import BaseSocket, NodeSocketNamespace
+from node_graph.socket import BaseSocket, NodeSocket, NodeSocketNamespace
 from node_graph.nodes import NodePool
 import operator as op
 
@@ -328,3 +328,18 @@ def test_set_socket_value():
     s._set_socket_value(value, link_limit=100000)
     assert s._value == value
     assert s.a._link_limit == 100000
+
+
+def test_set_namespace_attr():
+    ng = NodeGraph()
+    n = Node(parent=ng)
+    s = NodeSocketNamespace("a", node=n, graph=ng, metadata={"dynamic": True})
+    # auto create a sub-socket "x"
+    s.x = 1
+    assert s.x.value == 1
+    s1 = NodeSocket("b", node=n, graph=ng)
+    s.x = s1
+    assert len(s.x._links) == 1
+    s.y = s1
+    assert s.y.value is None
+    assert len(s.y._links) == 1


### PR DESCRIPTION
Override the `__setattr__`:
-  if the value is a socket, create a link
- otherwise, sets the underlying property value

Override the `__getattr__`:
- if the namespace is dynamic, create a socket if it not exist