### PR TITLE
Add zone analysis to `NodeGraphAnalysis`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,36 @@ def ng_complex(func_with_namespace_socket) -> NodeGraph:
 
 
 @pytest.fixture
+def ng_with_zone() -> NodeGraph:
+    """
+    Create a small NodeGraph:
+    zone1: n1, n2
+    zone2: n3, n4
+        n1 -> n2
+        n2 -> n3
+        n3 -> n4
+        n4 -> n5
+    """
+
+    ng = NodeGraph(name="test_graph")
+    zone1 = ng.add_node(NodePool.node_graph.test_add, name="zone1")
+    zone2 = ng.add_node(NodePool.node_graph.test_add, name="zone2")
+    n1 = ng.add_node(NodePool.node_graph.test_add, name="n1")
+    n2 = ng.add_node(NodePool.node_graph.test_add, name="n2")
+    n3 = ng.add_node(NodePool.node_graph.test_add, name="n3")
+    n4 = ng.add_node(NodePool.node_graph.test_add, name="n4")
+    n5 = ng.add_node(NodePool.node_graph.test_add, name="n5")
+    zone1.children = [n2, n3]
+    zone2.children = [n3, n4]
+    ng.add_link(n1.outputs.result, n2.inputs.x)
+    ng.add_link(n2.outputs.result, n3.inputs.x)
+    ng.add_link(n3.outputs.result, n4.inputs.x)
+    ng.add_link(n4.outputs.result, n5.inputs.x)
+
+    return ng
+
+
+@pytest.fixture
 def ng_group():
     ng = NodeGraph(name="test_node_group")
     # auto generate name for the node

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -106,3 +106,15 @@ def test_compare_graphs_with_changes(ng_complex, func_with_namespace_socket):
     assert "n4" in diff["modified_nodes"]
     # n1 not changed
     assert "n1" not in diff["modified_nodes"]
+
+
+def test_zone(ng_with_zone):
+    """
+    Two identical graphs => no added/removed/changed nodes
+    """
+    analysis = NodeGraphAnalysis(ng_with_zone)
+    zones = analysis.build_zone()
+    assert zones["zone1"]["input_tasks"] == ["n1"]
+    assert zones["zone2"]["input_tasks"] == ["zone1"]
+    assert zones["n3"]["input_tasks"] == ["zone1"]
+    assert zones["n5"]["input_tasks"] == ["zone2"]


### PR DESCRIPTION
- Introduce `build_zone()` public API to treat every node as a “zone” and compute external dependencies so consumers wait for entire producer-zones to complete.
- Add `_cache_zone` and integrate zone cache into existing caching infrastructure (_ensure_cache_valid/_rebuild_cache).
- Implement `_compute_zone_cache()` as a verbatim port of WorkGraphSaver’s assign/update/find logic: 
  - Build direct child to parent mappings 
  - Recursively gather raw inputs, recurse into child zones, filter internal sources, and collapse to nearest producer-zone via parent-chain intersection 
  - Cache per-node children and input_tasks