### PR TITLE
Add lshift and rshift operators for Node

### DIFF
--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -180,12 +180,22 @@ class WaitingOn:
         self.parent = parent
         self._waiting_on = set()
 
-    def add(self, socket: "BaseSocket") -> None:
+    def add(self, socket: "BaseSocket" | "Node") -> None:
         """Add a socket to the waiting list."""
-        if socket._node.name not in self._waiting_on:
-            self._waiting_on.add(socket._node.name)
+        from node_graph.node import Node
+
+        if isinstance(socket, BaseSocket):
+            node = socket._node
+        elif isinstance(socket, Node):
+            node = socket
+        else:
+            raise TypeError(
+                f"Expected BaseSocket or Node, got {type(socket).__name__}."
+            )
+        if node.name not in self._waiting_on:
+            self._waiting_on.add(node.name)
             self.parent._graph.add_link(
-                socket._node.outputs._wait, self.parent._node.inputs._wait
+                node.outputs._wait, self.parent._node.inputs._wait
             )
 
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -368,6 +368,14 @@ def test_socket_waiting_on():
     n1 = ng.add_node(NodePool.node_graph.test_add)
     n2 = ng.add_node(NodePool.node_graph.test_add)
     n3 = ng.add_node(NodePool.node_graph.test_add)
-    n1.outputs.result >> n3.inputs.x
-    n2.outputs.result >> n3.inputs.x
-    assert len(n3.inputs._wait._links) == 2
+    n4 = ng.add_node(NodePool.node_graph.test_add)
+    n5 = ng.add_node(NodePool.node_graph.test_add)
+    # left shift
+    # wait for socket
+    n1.outputs.result >> n5.inputs.x
+    # wait for node
+    n2.outputs.result >> n5
+    # rshift
+    n5 << n3.outputs.result
+    n5 << n4
+    assert len(n5.inputs._wait._links) == 4


### PR DESCRIPTION

Use a uniform `lshift` and `rshfit` operators API for both `Node` and `Socket`.

Here is an example:

```python
ng = NodeGraph(name="test_socket_waiting_on")
n1 = ng.add_node(NodePool.node_graph.test_add)
n2 = ng.add_node(NodePool.node_graph.test_add)
n3 = ng.add_node(NodePool.node_graph.test_add)
n4 = ng.add_node(NodePool.node_graph.test_add)
n5 = ng.add_node(NodePool.node_graph.test_add)
# left shift
# wait for socket
n1.outputs.result >> n5.inputs.x
# wait for node
n2.outputs.result >> n5
# rshift
n5 << n3.outputs.result
n5 << n4
assert len(n5.inputs._wait._links) == 4
```