### PR TITLE
Use dict for the sockets parameters in the decorator

### DIFF
--- a/src/node_graph/config.py
+++ b/src/node_graph/config.py
@@ -1,4 +1,4 @@
 builtin_inputs = [
-    {"name": "_wait", "link_limit": 1e6, "metadata": {"arg_type": "none"}}
+    {"name": "_wait", "link_limit": 1000000, "metadata": {"arg_type": "none"}}
 ]
 builtin_outputs = [{"name": "_wait"}, {"name": "_outputs"}]

--- a/src/node_graph/decorator.py
+++ b/src/node_graph/decorator.py
@@ -123,12 +123,12 @@ def generate_input_sockets(
                 input["property"]["default"] = kwarg["default"]
                 input["metadata"]["required"] = False
             inputs[name] = input
-    # if var_args in input_names, set the link_limit to 1e6 and the identifier to namespace
+    # if var_args in input_names, set the link_limit to 1000000 and the identifier to namespace
     if var_args is not None:
         has_var_args = False
         for name, input in inputs.items():
             if name == var_args:
-                input.setdefault("link_limit", 1e6)
+                input.setdefault("link_limit", 1000000)
                 if (
                     input.get("identifier", type_mapping["namespace"])
                     != type_mapping["namespace"]
@@ -144,13 +144,13 @@ def generate_input_sockets(
             inputs[var_args] = {
                 "identifier": type_mapping["namespace"],
                 "metadata": {"arg_type": "var_args", "function_socket": True},
-                "link_limit": 1e6,
+                "link_limit": 1000000,
             }
     if var_kwargs is not None:
         has_var_kwargs = False
         for name, input in inputs.items():
             if name == var_kwargs:
-                input.setdefault("link_limit", 1e6)
+                input.setdefault("link_limit", 1000000)
                 if (
                     input.get("identifier", type_mapping["namespace"])
                     != type_mapping["namespace"]
@@ -170,7 +170,7 @@ def generate_input_sockets(
                     "dynamic": True,
                     "function_socket": True,
                 },
-                "link_limit": 1e6,
+                "link_limit": 1000000,
             }
     final_inputs = {
         "name": "inputs",

--- a/src/node_graph/node.py
+++ b/src/node_graph/node.py
@@ -295,8 +295,8 @@ class Node:
             if data["metadata"].get(key):
                 setattr(self, key, data["metadata"].get(key))
         # properties first, because the socket may be dynamic
-        for prop in data.get("properties", {}).values():
-            self.properties[prop["name"]].value = prop["value"]
+        for name, prop in data.get("properties", {}).items():
+            self.properties[name].value = prop["value"]
         # inputs
         input_values = collect_values_inside_namespace(data["inputs"])
         self.inputs._set_socket_value(input_values)

--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -98,7 +98,7 @@ class NodeGraph:
         if "graph_ctx" not in self.nodes:
             ctx = self.nodes._new("graph_ctx", name="graph_ctx")
             ctx.inputs._metadata.dynamic = True
-            ctx.inputs._default_link_limit = 1e6
+            ctx.inputs._default_link_limit = 1000000
         return self.nodes["graph_ctx"]
 
     @property

--- a/src/node_graph/nodes/factory/base.py
+++ b/src/node_graph/nodes/factory/base.py
@@ -1,5 +1,4 @@
 from typing import Dict
-from node_graph.utils import list_to_dict
 from node_graph.node import Node
 import importlib
 
@@ -42,9 +41,10 @@ class BaseNodeFactory:
                 super().__init__(*args, **kwargs)
 
             def create_properties(self):
-                properties = list_to_dict(self._ndata.get("properties", {}))
-                for prop in properties.values():
+                properties = self._ndata.get("properties", {})
+                for name, prop in properties.items():
                     prop.setdefault("identifier", BaseClass.PropertyPool.any)
+                    prop["name"] = name
                     self.add_property(**prop)
 
             def create_sockets(self):

--- a/src/node_graph/nodes/factory/function_node.py
+++ b/src/node_graph/nodes/factory/function_node.py
@@ -2,7 +2,7 @@ from node_graph.orm.mapping import type_mapping
 from typing import Any, Callable, Dict, List, Optional
 from node_graph.config import builtin_inputs, builtin_outputs
 from node_graph.executor import NodeExecutor
-from node_graph.utils import list_to_dict
+from node_graph.utils import validate_socket_data
 from .base import BaseNodeFactory
 
 
@@ -32,9 +32,9 @@ class DecoratedFunctionNodeFactory(BaseNodeFactory):
         node_class = node_class or cls.default_base_class
 
         identifier = identifier or func.__name__
-        inputs = list_to_dict(inputs) or {}
-        properties = list_to_dict(properties) or {}
-        outputs = list_to_dict(outputs) or {}
+        inputs = validate_socket_data(inputs) or {}
+        properties = validate_socket_data(properties) or {}
+        outputs = validate_socket_data(outputs) or {}
         error_handlers = error_handlers or []
         node_inputs = generate_input_sockets(
             func, inputs, properties, type_mapping=type_mapping

--- a/src/node_graph/nodes/factory/function_node.py
+++ b/src/node_graph/nodes/factory/function_node.py
@@ -1,5 +1,5 @@
 from node_graph.orm.mapping import type_mapping
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional
 from node_graph.config import builtin_inputs, builtin_outputs
 from node_graph.executor import NodeExecutor
 from node_graph.utils import list_to_dict
@@ -15,9 +15,9 @@ class DecoratedFunctionNodeFactory(BaseNodeFactory):
         func: Callable,
         identifier: Optional[str] = None,
         node_type: str = "Normal",
-        properties: Optional[List[Tuple[str, str]]] = None,
-        inputs: Optional[List[Union[str, dict]]] = None,
-        outputs: Optional[List[Union[str, dict]]] = None,
+        properties: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        outputs: Optional[Dict[str, Any]] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
         catalog: str = "Others",
         additional_data: Optional[Dict[str, Any]] = None,
@@ -32,9 +32,9 @@ class DecoratedFunctionNodeFactory(BaseNodeFactory):
         node_class = node_class or cls.default_base_class
 
         identifier = identifier or func.__name__
-        inputs = inputs or []
-        properties = properties or []
-        outputs = outputs or []
+        inputs = list_to_dict(inputs) or {}
+        properties = list_to_dict(properties) or {}
+        outputs = list_to_dict(outputs) or {}
         error_handlers = error_handlers or []
         node_inputs = generate_input_sockets(
             func, inputs, properties, type_mapping=type_mapping
@@ -43,7 +43,7 @@ class DecoratedFunctionNodeFactory(BaseNodeFactory):
         node_outputs = {
             "name": "outputs",
             "identifier": node_class.SocketPool.any,
-            "sockets": list_to_dict(outputs),
+            "sockets": outputs,
         }
         for out in node_outputs["sockets"].values():
             out.setdefault("metadata", {})

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -528,7 +528,7 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
         name: str,
         node: Optional["Node"] = None,
         parent: Optional["NodeSocket"] = None,
-        link_limit: int = 1e6,
+        link_limit: int = 1000000,
         metadata: Union[SocketMetadata, Dict[str, Any], None] = None,
         sockets: Optional[Dict[str, object]] = None,
         pool: Optional[object] = None,
@@ -560,7 +560,7 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
             self._SocketPool = SocketPool
 
         if self._metadata.dynamic:
-            self._link_limit = 1e6
+            self._link_limit = 1000000
         if sockets is not None:
             for key, socket in sockets.items():
                 kwargs = {}

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -747,7 +747,8 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
             **kwargs,
         )
         # Add nested sockets
-        for item_data in data.get("sockets", {}).values():
+        for name, item_data in data.get("sockets", {}).items():
+            item_data["name"] = name
             ns._new(**item_data)
         return ns
 

--- a/src/node_graph/utils.py
+++ b/src/node_graph/utils.py
@@ -24,11 +24,18 @@ def get_executor_from_path(path: dict | str) -> Any:
     return executor
 
 
-def list_to_dict(data: List[Dict[str, Any]]) -> Dict[str, Any]:
+def list_to_dict(data: List[str]) -> Dict[str, Any]:
     """Convert list to dict."""
-    if isinstance(data, dict):
+    if data is None:
+        return {}
+    if isinstance(data, list):
+        if not all(isinstance(d, str) for d in data):
+            raise TypeError("All elements in the list must be strings")
+        return {d: {} for d in data}
+    elif isinstance(data, dict):
         return data
-    return {d["name"]: d for d in data}
+    else:
+        raise TypeError(f"Expected list or dict, got {type(data).__name__}")
 
 
 def nodegaph_to_short_json(

--- a/src/node_graph/utils.py
+++ b/src/node_graph/utils.py
@@ -24,8 +24,11 @@ def get_executor_from_path(path: dict | str) -> Any:
     return executor
 
 
-def list_to_dict(data: List[str]) -> Dict[str, Any]:
-    """Convert list to dict."""
+def validate_socket_data(data: List[str]) -> Dict[str, Any]:
+    """Validate socket data and convert it to a dictionary.
+    If data is None, return an empty dictionary.
+    If data is a list, convert it to a dictionary with empty dictionaries as values.
+    """
     if data is None:
         return {}
     if isinstance(data, list):
@@ -93,14 +96,14 @@ def yaml_to_dict(data: Dict[str, Any]) -> Dict[str, Any]:
     ntdata["nodes"] = {}
     for node in nodes:
         node.setdefault("metadata", {})
-        node["properties"] = list_to_dict(node.get("properties", {}))
+        node["properties"] = validate_socket_data(node.get("properties", {}))
         node["inputs"] = {
             "name": "inputs",
-            "sockets": list_to_dict(node.get("inputs", {})),
+            "sockets": validate_socket_data(node.get("inputs", {})),
         }
         node["outputs"] = {
             "name": "outputs",
-            "sockets": list_to_dict(node.get("outputs", {})),
+            "sockets": validate_socket_data(node.get("outputs", {})),
         }
         ntdata["nodes"][node["name"]] = node
     return ntdata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,20 +22,20 @@ def node_with_namespace_socket():
 @pytest.fixture
 def func_with_namespace_socket():
     @node(
-        inputs=[
-            {"name": "nested", "identifier": "node_graph.namespace"},
-            {"name": "nested.d"},
-            {"name": "nested.f", "identifier": "node_graph.namespace"},
-            {"name": "nested.f.g"},
-            {"name": "nested.f.h"},
-        ],
-        outputs=[
-            {"name": "sum"},
-            {"name": "product"},
-            {"name": "nested", "identifier": "node_graph.namespace"},
-            {"name": "nested.sum"},
-            {"name": "nested.product"},
-        ],
+        inputs={
+            "nested": {"identifier": "node_graph.namespace"},
+            "nested.d": {},
+            "nested.f": {"identifier": "node_graph.namespace"},
+            "nested.f.g": {},
+            "nested.f.h": {},
+        },
+        outputs={
+            "sum": {},
+            "product": {},
+            "nested": {"identifier": "node_graph.namespace"},
+            "nested.sum": {},
+            "nested.product": {},
+        },
     )
     def func(a, b=1, nested={}):
         return {
@@ -140,9 +140,7 @@ def ng_group():
 def decorated_myadd():
     """Generate a decorated node for test."""
 
-    @node(
-        outputs=[{"identifier": "node_graph.any", "name": "result"}],
-    )
+    @node()
     def myadd(x: float, y: float, t: float = 1):
         import time
 
@@ -157,7 +155,7 @@ def decorated_myadd_group(decorated_myadd):
     """Generate a decorated node group for test."""
     myadd = decorated_myadd
 
-    @node.graph_builder(outputs=[{"name": "result"}])
+    @node.graph_builder(outputs={"result": {"identifier": "node_graph.any"}})
     def myaddgroup(x, y):
         ng = NodeGraph()
         add1 = ng.add_node(myadd, "add1")
@@ -180,11 +178,11 @@ def node_with_decorated_node(decorated_myadd):
 
     @node(
         identifier="node_with_decorated_node",
-        inputs=[
-            {"identifier": "node_graph.float", "name": "x"},
-            {"identifier": "node_graph.float", "name": "y"},
-        ],
-        outputs=[{"identifier": "node_graph.any", "name": "result"}],
+        inputs={
+            "x": {"identifier": "node_graph.float"},
+            "y": {"identifier": "node_graph.float"},
+        },
+        outputs={"result": {"identifier": "node_graph.any"}},
     )
     def node_with_decorated_node(x, y):
         ng = NodeGraph("node_in_decorated_node")

--- a/tests/datas/test_yaml.yaml
+++ b/tests/datas/test_yaml.yaml
@@ -7,12 +7,12 @@ nodes:
   - identifier: node_graph.test_float
     name: float1
     properties:
-      - name: value
+      value:
         value: 2.0
   - identifier: node_graph.test_add
     name: add1
     inputs:
-      - name: y
+      y:
         property:
           value: 3.0
 links:

--- a/tests/test_builtin_nodes.py
+++ b/tests/test_builtin_nodes.py
@@ -11,7 +11,7 @@ def test_builtin_nodes() -> None:
     assert ng.inputs._metadata.dynamic is True
     assert ng.outputs._metadata.dynamic is True
     assert ng.ctx._metadata.dynamic is True
-    assert ng.ctx._default_link_limit == 1e6
+    assert ng.ctx._default_link_limit == 1000000
     assert len(ng.inputs) == 2
     assert len(ng.outputs) == 1
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -101,7 +101,7 @@ def test_decorator_parameters() -> None:
         return {"sum": a + b, "product": a * b}
 
     test1 = test._NodeCls()
-    assert test1.inputs["kwargs"]._link_limit == 1e6
+    assert test1.inputs["kwargs"]._link_limit == 1000000
     assert test1.inputs["kwargs"]._identifier == "node_graph.namespace"
     # user defined the c input manually
     assert "c" in test1.get_input_names()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -37,7 +37,7 @@ def test_create_node():
     """Build node on-the-fly."""
     ndata = {
         "identifier": "add",
-        "properties": [{"identifier": "node_graph.float", "name": "x", "default": 3}],
+        "properties": {"x": {"identifier": "node_graph.float", "default": 3}},
         "inputs": {
             "name": "inputs",
             "identifier": "node_graph.namespace",
@@ -93,9 +93,9 @@ def test_decorator_parameters() -> None:
     """Test passing parameters to decorators."""
 
     @node(
-        inputs=[{"name": "c"}, {"name": "kwargs"}],
-        properties=[{"name": "d", "default": 3}],
-        outputs=[{"name": "sum"}, {"name": "product"}],
+        inputs={"c": {}, "kwargs": {}},
+        properties={"d": {"default": 3}},
+        outputs={"sum": {}, "product": {}},
     )
     def test(*x, a, b=1, **kwargs):
         return {"sum": a + b, "product": a * b}
@@ -117,7 +117,7 @@ def test_decorator_parameters() -> None:
 
 
 def test_socket():
-    @node(outputs=[{"name": "sum"}, {"name": "product"}])
+    @node(outputs={"sum": {}, "product": {}})
     def func(x: int, y: int = 1):
         return {"sum": x + y, "product": x * y}
 
@@ -126,6 +126,8 @@ def test_socket():
     assert "product" in outputs
     assert outputs._node.inputs.x._identifier == "node_graph.int"
     assert outputs._node.inputs.y.property.default == 1
+    # test socket order
+    assert outputs[0]._name == "sum"
 
 
 def create_test_node_group():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -81,20 +81,20 @@ def test_get_items(ng):
 
 def test_load_graph():
     @node(
-        inputs=[
-            {"name": "nested", "identifier": "node_graph.namespace"},
-            {"name": "nested.d"},
-            {"name": "nested.f", "identifier": "node_graph.namespace"},
-            {"name": "nested.f.g"},
-            {"name": "nested.f.h"},
-        ],
-        outputs=[
-            {"name": "sum"},
-            {"name": "product"},
-            {"name": "nested", "identifier": "node_graph.namespace"},
-            {"name": "nested.sum"},
-            {"name": "nested.product"},
-        ],
+        inputs={
+            "nested": {"identifier": "node_graph.namespace"},
+            "nested.d": {},
+            "nested.f": {"identifier": "node_graph.namespace"},
+            "nested.f.g": {},
+            "nested.f.h": {},
+        },
+        outputs={
+            "sum": {},
+            "product": {},
+            "nested": {"identifier": "node_graph.namespace"},
+            "nested.sum": {},
+            "nested.product": {},
+        },
     )
     def test(a, b=1, nested={}):
         return {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+from node_graph.utils import validate_socket_data
+
+
+def test_validate_socket_data():
+    """Test the validate_socket_data function to ensure it correctly validates socket data."""
+    input_list = ["sum", "diff"]
+    result = validate_socket_data(input_list)
+    assert result == {"sum": {}, "diff": {}}


### PR DESCRIPTION

See this [discussion](https://github.com/aiidateam/aiida-workgraph/issues/584). Because from Python 3.7, the insertion order is guaranteed, so dict is preferred because it makes the code clean and straightforward. 
For example,
old syntax, using list
```python
@node(outputs=[{"name": "sum", "identifier": "node_graph.int"},
                {"name": "diff", "identifier": "node_graph.int"}
])
def sum_diff(x, y):
    return x+y, x-y
```
new syntax, using dict
```python
@node(outputs={"sum": {"identifier": "node_graph.int"},
                "diff": {"identifier": "node_graph.int"},
})
def sum_diff(x, y):
    return x+y, x-y
```

At the same time, the new syntax also supports 
```python
@node(outputs=["sum", "diff"])
def sum_diff(x, y):
    return x+y, x-y
```