### PR TITLE
Accept a list/tuple of keys for `NodeGraph` inputs

### DIFF
--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -4,7 +4,7 @@ from node_graph.collection import NodeCollection, LinkCollection
 from uuid import uuid1
 from node_graph.sockets import SocketPool
 from node_graph.nodes import NodePool
-from typing import Dict, Any, List, Optional, Union, Callable
+from typing import Dict, Any, List, Optional, Tuple, Union, Callable
 import yaml
 from node_graph.node import Node
 from node_graph.socket import NodeSocket
@@ -107,7 +107,7 @@ class NodeGraph:
         return self.graph_inputs.inputs
 
     @inputs.setter
-    def inputs(self, value: Dict[str, Any]) -> None:
+    def inputs(self, value: Dict[str, Any] | List[str] | Tuple[str]) -> None:
         """Set group inputs node."""
         self.graph_inputs.inputs._clear()
         self.graph_inputs.inputs._set_socket_value(value)

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from node_graph.collection import DependencyCollection
 from node_graph.property import NodeProperty
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 from node_graph.collection import get_item_class, EntryPointPool
 from dataclasses import dataclass, field, asdict
 
@@ -674,13 +674,20 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
     def _value(self, value: Dict[str, Any]) -> None:
         self._set_socket_value(value)
 
-    def _set_socket_value(self, value: Dict[str, Any] | NodeSocket, **kwargs) -> None:
+    def _set_socket_value(
+        self,
+        value: Dict[str, Any] | List[str] | Tuple[str] | NodeSocket,
+        **kwargs,
+    ) -> None:
         """Set the value of the socket.
         In the kwargs, one can specify the pool, link_limit, metadata etc"""
         if value is None:
             return
         if isinstance(value, BaseSocket):
             self._node.graph.add_link(value, self)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                self._new(self._SocketPool["any"], item, **kwargs)
         elif isinstance(value, dict):
             for key, val in value.items():
                 if key not in self:

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -686,8 +686,7 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
         if isinstance(value, BaseSocket):
             self._node.graph.add_link(value, self)
         elif isinstance(value, (list, tuple)):
-            for item in value:
-                self._new(self._SocketPool["any"], item, **kwargs)
+            self._set_socket_value(dict.fromkeys(value), **kwargs)
         elif isinstance(value, dict):
             for key, val in value.items():
                 if key not in self:

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -338,11 +338,19 @@ def test_unpacking():
     assert b.value == 2
 
 
-def test_set_socket_value():
+@pytest.mark.parametrize(
+    "value, expected_value",
+    [
+        ({"a": 1, "b": 2}, {"a": 1, "b": 2}),
+        (("a", "b"), {}),
+        (["a", "b"], {}),
+    ],
+)
+def test_set_socket_value(value, expected_value):
     s = NodeSocketNamespace("test", metadata={"dynamic": True})
-    value = {"a": 1, "b": 2}
     s._set_socket_value(value, link_limit=100000)
-    assert s._value == value
+    assert s._value == expected_value
+    assert all(key in s for key in value)
     assert s.a._link_limit == 100000
 
 


### PR DESCRIPTION
Allow `list`/`tuple` when setting sockets.