### PR TITLE
Fix graph level sockets

### DIFF
--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -82,6 +82,11 @@ class NodeGraph:
         if "graph_inputs" not in self.nodes:
             graph_inputs = self.nodes._new("graph_inputs", name="graph_inputs")
             graph_inputs.inputs._metadata.dynamic = True
+            # Because the the graph_inputs socket can be linked to multiple tasks
+            # A temporary fix to allow more multiple links
+            # But we should distinguish between the input and output links
+            # and allow only one link per input socket by default
+            graph_inputs.inputs._default_link_limit = 1000000
         return self.nodes["graph_inputs"]
 
     @property

--- a/src/node_graph/nodes/builtins.py
+++ b/src/node_graph/nodes/builtins.py
@@ -32,8 +32,8 @@ class GraphLevelNode(Node):
 
         metadata = super().get_metadata()
         metadata["node_class"] = {
-            "module_path": self.node_class.__module__,
-            "callable_name": self.node_class.__name__,
+            "module_path": self.__class__.__module__,
+            "callable_name": self.__class__.__name__,
         }
         metadata["factory_class"] = {
             "module_path": self.factory_class.__module__,

--- a/src/node_graph/property.py
+++ b/src/node_graph/property.py
@@ -36,6 +36,7 @@ class NodeProperty:
         self.update = update
         self.arg_type = arg_type
         self._value = default
+        self._value_id = None
         if value is not None:
             self.value = value
 
@@ -90,6 +91,8 @@ class NodeProperty:
         """Set the value and invoke the update callback if present."""
         self.validate(value)
         self._value = value
+        # Store the ID of the value to track link
+        self._value_id = id(value)
         if self.update:
             self.update()
 

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -802,9 +802,10 @@ class NodeSocketNamespace(BaseSocket, OperatorSocketMixin):
                 if len(keys) > 1:
                     return item[keys[1]]
                 return item
+            parent = self._parent or self._node
             raise AttributeError(
                 f""""{key}" is not in the {self.__class__.__name__}.
-Acceptable names are {self._get_keys()}. This collection belongs to {self._parent}."""
+Acceptable names are {self._get_keys()}. This collection belongs to {parent}."""
             )
 
     def __contains__(self, name: str) -> bool:

--- a/src/node_graph/utils.py
+++ b/src/node_graph/utils.py
@@ -179,3 +179,27 @@ def valid_name_string(s: str) -> bool:
         raise ValueError(
             f"Invalid name: {s!r}. Only letters, digits and underscores are allowed"
         )
+
+
+def socket_value_id_mapping(socket):
+    """Create a mapping of value IDs to sockets in a NodeSocketNamespace."""
+    from node_graph.socket import NodeSocketNamespace
+
+    mapping = {}
+    for sub_socket in socket._sockets.values():
+        if isinstance(sub_socket, NodeSocketNamespace):
+            sub_mapping = socket_value_id_mapping(sub_socket)
+            for value_id, socket_list in sub_mapping.items():
+                if value_id in mapping:
+                    mapping[value_id].extend(socket_list)
+                else:
+                    mapping[value_id] = socket_list
+        else:
+            value_id = sub_socket.property._value_id
+            if sub_socket.property.value is None:
+                continue
+            if value_id in mapping:
+                mapping[value_id].append(sub_socket)
+            else:
+                mapping[value_id] = [sub_socket]
+    return mapping

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -439,3 +439,28 @@ def test_socket_group_waiting_on():
     assert len(n3.inputs._wait._links) == 2
     assert n3.inputs._wait._links[0].from_node.name == n1.name
     assert n3.inputs._wait._links[1].from_node.name == n2.name
+
+
+def test_value_id_mapping():
+    """Test socket value id mapping."""
+    from node_graph.utils import socket_value_id_mapping
+
+    s = NodeSocketNamespace("test", metadata={"dynamic": True})
+    # single value
+    a = 1
+    # nested socket
+    b = {"sub_b": 2}
+    # list value
+    c = [3, 4]
+    s._value = {
+        "a": a,
+        "b": b,
+        "c": c,
+        "another_a": a,  # the same input are passed to different sockets
+    }
+    mapping = socket_value_id_mapping(s)
+    assert mapping == {
+        id(a): [s.a, s.another_a],
+        id(b["sub_b"]): [s.b.sub_b],
+        id(c): [s.c],
+    }


### PR DESCRIPTION
To auto-detect the graph-level inputs from the function input, and track which tasks the inputs are passed into during runtime, as mentioned in this [issue](https://github.com/aiidateam/aiida-workgraph/issues/603), and this [PR](https://github.com/aiidateam/aiida-workgraph/pull/614).
This PR 
- adds a `_value_id` attribute to the Property class, so that when assigning the value to the proper, it also tracks the original `id` of the value.
- provides a utils function to get the "value" and "id" mapping of a namespace socket
