### PR TITLE
Build graph level inputs and outputs from spec

### DIFF
--- a/tests/test_builtin_nodes.py
+++ b/tests/test_builtin_nodes.py
@@ -11,7 +11,7 @@ def test_builtin_nodes() -> None:
     assert ng.inputs._metadata.dynamic is True
     assert ng.outputs._metadata.dynamic is True
     assert ng.ctx._metadata.dynamic is True
-    assert ng.ctx._default_link_limit == 1000000
+    assert ng.ctx._metadata.sub_socket_default_link_limit == 1000000
     assert len(ng.inputs) == 2
     assert len(ng.outputs) == 1
 

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -108,3 +108,19 @@ def test_load_graph():
     ng1 = NodeGraph.from_dict(ngdata)
     assert "sum" in ng1.nodes.test1.outputs.nested
     assert ng1.nodes.test1.inputs._value == ng.nodes.test1.inputs._value
+
+
+def test_build_graph_inputs_outputs(ng):
+    """Test build graph inputs and outputs."""
+    ng = NodeGraph(
+        name="test_graph_inputs_outputs",
+        inputs=spec.namespace(a=any, b=any, c=spec.namespace(x=any, y=any)),
+        outputs=spec.namespace(
+            sum=any, product=any, nested=spec.namespace(sum=any, product=any)
+        ),
+    )
+    assert "a" in ng.inputs
+    assert "x" in ng.inputs.c
+    assert "sum" in ng.outputs
+    assert "sum" in ng.outputs.nested
+    assert ng.inputs._metadata.sub_socket_default_link_limit == 1000000


### PR DESCRIPTION
Use the new `spec` api to define the graph-level inputs and outputs.

Here is an example: 
**Before**
One defined the inputs and set the values at the same time.
```python
ng = NodeGraph()
ng.inputs = {"x": 1, "y": 2}
```

**After**
One defines the inputs during the initialization of the graph, then assigns the values with validation.
```python
ng = NodeGraph(inputs=spec.namespace(x=any, y=any)
# use the inputs
ng.inputs = {"x": 1, "y": 2}
# this will raise an error, because "z" does not exist in the namespace.
ng.inputs = {"z": 3}
```