### PR TITLE
Expose named inputs outputs

### DIFF
--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -180,15 +180,13 @@ class NodeGraph:
     def generate_inputs(self, names: Optional[List[str]] = None) -> None:
         """Generate group inputs from nodes."""
         self.inputs._clear()
-        if names is not None:
-            unused_names = names.copy()
-        for node in self.nodes:
-            if node.name in BUILTIN_NODES:
-                continue
-            if names is not None:
-                if node.name not in names:
-                    continue
-                unused_names.remove(node.name)
+        all_names = set(self.nodes._get_keys())
+        names = set(names or all_names)
+        missing = names - all_names
+        if missing:
+            raise ValueError(f"The following named nodes do not exist: {missing}")
+        for name in names - set(BUILTIN_NODES):
+            node = self.nodes[name]
             # skip linked sockets
             socket = node.inputs._copy(
                 node=self.graph_inputs,
@@ -206,25 +204,17 @@ class NodeGraph:
                     continue
                 # add link from group inputs to node inputs
                 self.add_link(self.inputs[new_key], node.inputs[key])
-        if names is not None:
-            # Check there are no unused names left
-            if unused_names:
-                raise ValueError(
-                    f"The following named nodes do not exist: {unused_names}"
-                )
 
     def generate_outputs(self, names: Optional[List[str]] = None) -> None:
         """Generate group outputs from nodes."""
         self.outputs._clear()
-        if names is not None:
-            unused_names = names.copy()
-        for node in self.nodes:
-            if node.name in BUILTIN_NODES:
-                continue
-            if names is not None:
-                if node.name not in names:
-                    continue
-                unused_names.remove(node.name)
+        all_names = set(self.nodes._get_keys())
+        names = set(names or all_names)
+        missing = names - all_names
+        if missing:
+            raise ValueError(f"The following named nodes do not exist: {missing}")
+        for name in names - set(BUILTIN_NODES):
+            node = self.nodes[name]
             socket = node.outputs._copy(
                 node=self.graph_outputs,
                 parent=self.outputs,
@@ -240,12 +230,6 @@ class NodeGraph:
                     continue
                 # add link from node outputs to group outputs
                 self.add_link(node.outputs[key], self.outputs[new_key])
-        if names is not None:
-            # Check there are no unused names left
-            if unused_names:
-                raise ValueError(
-                    f"The following named nodes do not exist: {unused_names}"
-                )
 
     def set_inputs(self, inputs: Dict[str, Any]):
         for name, input in inputs.items():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -139,10 +139,14 @@ def test_generate_inputs_names(ng):
     assert ng.inputs.add2._value == ng.nodes["add2"].inputs._value
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_generate_inputs_names_invalid(ng):
     """Test that input generation fails for invalid name"""
-    ng.generate_inputs(names=["missing"])
+    name = "missing"
+    with pytest.raises(
+        ValueError,
+        match="The following named nodes do not exist:",
+    ):
+        ng.generate_inputs(names=[name])
 
 
 def test_generate_outputs(ng):
@@ -161,10 +165,14 @@ def test_generate_outputs_names(ng):
     assert "add2" not in ng.outputs
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_generate_outputs_names_invalid(ng):
     """Test that output generation fails for invalid name"""
-    ng.generate_outputs(names=["missing"])
+    name = "missing"
+    with pytest.raises(
+        ValueError,
+        match="The following named nodes do not exist:",
+    ):
+        ng.generate_outputs(names=[name])
 
 
 def test_build_inputs_outputs(ng):


### PR DESCRIPTION
This PR adds an additional parameter to the `NodeGraph` `generate_inputs` and `generate_outputs` to expose only a subset of named nodes. See also the discussion at https://github.com/aiidateam/aiida-workgraph/discussions/624.