### PR TITLE
Allow set default value of a SocketSpec

### DIFF
--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -444,12 +444,6 @@ class BaseSpecInferAPI:
         return bool(spec.dynamic or spec.fields)
 
     @classmethod
-    def _set_leaf_default(cls, spec: SocketSpec, value: Any) -> SocketSpec:
-        if spec.is_namespace():
-            raise TypeError("Cannot set a scalar default on a namespace.")
-        return replace(spec, default=value)
-
-    @classmethod
     def _apply_structured_defaults_to_leaves(
         cls, ns_spec: SocketSpec, dv: dict[str, Any]
     ) -> SocketSpec:
@@ -496,7 +490,7 @@ class BaseSpecInferAPI:
 
     @classmethod
     def build_inputs_from_signature(
-        cls, func, explicit: SocketSpec | None
+        cls, func, explicit: SocketSpec | None = None
     ) -> SocketSpec:
         """Always return a NAMESPACE spec (possibly empty).
         - POSITIONAL_ONLY -> call_role="args"

--- a/tests/test_socket_spec.py
+++ b/tests/test_socket_spec.py
@@ -15,7 +15,7 @@ def test_namespace_build_and_roundtrip():
     )
     assert ns.identifier == tm["namespace"]
     assert set(ns.fields.keys()) == {"a", "b", "c"}
-    assert ns.defaults == {"b": 5}
+    assert ns.fields["b"].default == 5
     assert ns.fields["c"].identifier == tm["namespace"]
     assert set(ns.fields["c"].fields.keys()) == {"d"}
 
@@ -47,7 +47,6 @@ def test_expose_include_exclude_prefix_rename():
     # include/only
     inc = ss.expose(base, include=["foo", "baz"])
     assert set(inc.fields.keys()) == {"foo", "baz"}
-    assert inc.defaults == {}
 
     only = base.only("bar")
     assert set(only.fields.keys()) == {"bar"}


### PR DESCRIPTION
- Store the default in the leaf directly instead of the namespace, thus keeping the single truth of the source.
- Add helper function `set_default` to set the default value of a leaf in the namespace.

This PR is used to fix this https://github.com/aiidateam/aiida-workgraph/issues/650, one can set
```python
new_inputs = set_default(spec.inputs, "metadata.use_pickle", True)
```