### PR TITLE
Rename `build_graph` to `build`

### DIFF
--- a/docs/gallery/autogen/quick_start.py
+++ b/docs/gallery/autogen/quick_start.py
@@ -74,7 +74,7 @@ def add_multiply(x, y, z):
 # Build the node group
 #
 
-ng = add_multiply.build_graph(1, 2, 3)
+ng = add_multiply.build(1, 2, 3)
 ng.to_html()
 
 

--- a/docs/gallery/concept/autogen/graph_node_concept.py
+++ b/docs/gallery/concept/autogen/graph_node_concept.py
@@ -40,7 +40,7 @@ def add_multiply(x, y, z):
 # Build the node group
 #
 
-ng = add_multiply.build_graph(1, 2, 3)
+ng = add_multiply.build(1, 2, 3)
 ng.to_html()
 
 

--- a/src/node_graph/node_spec.py
+++ b/src/node_graph/node_spec.py
@@ -186,7 +186,7 @@ class BaseHandle:
 
         return node.outputs
 
-    def build_graph(self, /, *args, **kwargs):
+    def build(self, /, *args, **kwargs):
         from node_graph.utils.graph import materialize_graph
 
         if self._spec.metadata.get("node_type", "").upper() != "GRAPH":

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -152,6 +152,6 @@ def test_use_socket_view():
     def test_graph(a, b):
         return test(a, b)
 
-    graph = test_graph.build_graph(a=1, b=2)
+    graph = test_graph.build(a=1, b=2)
     assert "sum" in graph.outputs
     assert "product" in graph.outputs

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -123,7 +123,7 @@ def test_load_graph():
     assert ng1.nodes.test1.inputs._value == ng.nodes.test1.inputs._value
 
 
-def test_build_graph_inputs_outputs(ng):
+def test_build_inputs_outputs(ng):
     """Test build graph inputs and outputs."""
     ng = NodeGraph(
         name="test_graph_inputs_outputs",

--- a/tests/test_socket_spec.py
+++ b/tests/test_socket_spec.py
@@ -205,7 +205,7 @@ def test_expose_node_spec():
         tc = test_calc(x)
         return {"out1": am, "out2": tc.square}
 
-    ng = test_graph.build_graph(x=1, data={"y": 2})
+    ng = test_graph.build(x=1, data={"y": 2})
     assert "sum" in ng.outputs.out1
     assert "out2" in ng.outputs
     assert isinstance(ng.outputs.out1, NodeSocketNamespace)

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -2,7 +2,7 @@ from node_graph import NodeGraph
 
 
 def test_subgraph(decorated_myadd_group):
-    sub_ng = decorated_myadd_group.build_graph(x=1, y=2)
+    sub_ng = decorated_myadd_group.build(x=1, y=2)
     ng = NodeGraph(name="test_outputs")
     node1 = ng.add_node(sub_ng, "sub_ng", y=9)
     assert node1.name == "sub_ng"
@@ -11,7 +11,7 @@ def test_subgraph(decorated_myadd_group):
 
 
 def test_subgraph_link(decorated_myadd_group, decorated_myadd):
-    sub_ng = decorated_myadd_group.build_graph(x=1, y=2)
+    sub_ng = decorated_myadd_group.build(x=1, y=2)
     ng = NodeGraph(name="test_outputs")
     add1 = ng.add_node(decorated_myadd, "add1", x=2, y=3)
     node1 = ng.add_node(sub_ng, "sub_ng", x=add1.outputs.result, y=9)


### PR DESCRIPTION
- rename `build_graph` to `build`
- raise error if the return output sockets does not match the specification.