### PR TITLE
Add `SocketSpecSelect` and support nested path

### DIFF
--- a/tests/test_node_handle.py
+++ b/tests/test_node_handle.py
@@ -23,9 +23,6 @@ def test_nodehandle_inputs_outputs_view():
     # selection works
     assert isinstance(iv.x, ss.SocketView)
     assert isinstance(ov.sum, ss.SocketView)
-    # transforms
-    only_y = iv.only("y").to_spec()
-    assert set(only_y.fields.keys()) == {"y"}
 
 
 def test_nodehandle_call_flow():


### PR DESCRIPTION
- Remove SocketSpec/SocketView mutators (include/exclude/only/rename/prefix)
- Add SocketSpecSelect (include/exclude with dotted paths, include/exclude_prefix, rename, prefix).
- Apply selection + meta in namespace() and input/output inference.
- Add internal helpers for dotted-path transforms; update tests.

Example
```python
inputs: Annotated[
        dict,
        spec.namespace(
            relax=Annotated[dict, 
                            PwRelaxTask.inputs,
                            SocketSpecSelect(exclude="structure")],
            scf=Annotated[dict,
                          PwBaseTask.inputs,
                          SocketSpecSelect(exclude="pw.structure")],
    ] = None,
```