### PR TITLE
Support Pydantic model or dataclass for inputs/outputs specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "node-graph-widget",
     "wrapt",
     "typing_extensions>=4.7; python_version < '3.11'",
+    'pydantic~=2.6',
 ]
 
 [project.urls]

--- a/src/node_graph/decorator.py
+++ b/src/node_graph/decorator.py
@@ -7,26 +7,6 @@ from .node_spec import NodeHandle, BaseHandle
 from .socket_spec import SocketSpec
 
 
-def set_node_arguments(call_args, call_kwargs, node):
-    input_names = node.inputs._get_keys()
-    for i, value in enumerate(call_args):
-        if i < len(input_names):
-            node.inputs[input_names[i]].value = value
-        else:
-            # Does not support var_args yet
-            raise TypeError(
-                f"Too many positional arguments. expects {len(input_names)} but you supplied {len(call_args)}."
-            )
-    node.set_inputs(call_kwargs)
-    outputs = [
-        output for output in node.outputs if output._name not in ["_wait", "_outputs"]
-    ]
-    if len(outputs) == 1:
-        return outputs[0]
-    else:
-        return node.outputs
-
-
 def build_node_from_callable(
     executor: Callable,
     inputs: Optional[SocketSpec | List[str]] = None,

--- a/src/node_graph/node.py
+++ b/src/node_graph/node.py
@@ -11,7 +11,7 @@ from node_graph.collection import (
 )
 from .executor import SafeExecutor, BaseExecutor
 from .error_handler import ErrorHandlerSpec
-from node_graph.socket_spec import BaseSocketSpecAPI, SocketSpec, add_spec_field
+from node_graph.socket_spec import SocketSpecAPI, SocketSpec, add_spec_field
 from .config import BuiltinPolicy
 from .node_spec import NodeSpec, SchemaSource
 from dataclasses import replace
@@ -39,7 +39,7 @@ class Node:
 
     _REGISTRY: Optional[RegistryHub] = registry_hub
     _PROPERTY_CLASS = PropertyCollection
-    _SOCKET_SPEC_API = BaseSocketSpecAPI
+    _SOCKET_SPEC_API = SocketSpecAPI
     _BUILTINS_POLICY = BuiltinPolicy()
 
     _default_spec = NodeSpec(

--- a/src/node_graph/node_graph.py
+++ b/src/node_graph/node_graph.py
@@ -3,7 +3,7 @@ from node_graph.registry import RegistryHub, registry_hub
 from node_graph.collection import NodeCollection, LinkCollection
 from uuid import uuid1
 from node_graph.node_spec import NodeSpec
-from node_graph.socket_spec import SocketSpec, BaseSocketSpecAPI
+from node_graph.socket_spec import SocketSpec, SocketSpecAPI
 from typing import Dict, Any, List, Optional, Union, Callable
 import yaml
 from node_graph.node import Node
@@ -44,7 +44,7 @@ class NodeGraph:
 
     _REGISTRY: Optional[RegistryHub] = registry_hub
     _BUILTINS_POLICY = BuiltinPolicy()
-    _SOCKET_SPEC_API = BaseSocketSpecAPI
+    _SOCKET_SPEC_API = SocketSpecAPI
 
     platform: str = "node_graph"
 

--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -131,6 +131,10 @@ def _extract_spec_from_annotated(tp: Any) -> Optional["SocketSpec"]:
     for m in metas:
         if isinstance(m, SocketSpec):
             return m
+    # Pydantic BaseModel in metadata
+    for m in metas:
+        if isinstance(m, type) and _is_pydantic_model_type(m):
+            return SocketSpecAPI.from_model(m)
     return None
 
 

--- a/tests/test_graph_node.py
+++ b/tests/test_graph_node.py
@@ -63,7 +63,7 @@ def test_invalid_outputs():
     def add_multiply(x, y):
         return x + y
 
-    with pytest.raises(TypeError, match="Unsupported output type"):
+    with pytest.raises(TypeError, match="Invalid graph return payload."):
         add_multiply.build(x=2, y=3)
 
     # dict with invalid type
@@ -71,7 +71,7 @@ def test_invalid_outputs():
     def add_multiply(x, y):
         return {"sum": add(x, y).result, "product": x * y}
 
-    with pytest.raises(TypeError, match="Invalid output at"):
+    with pytest.raises(TypeError, match="Invalid graph return payload."):
         add_multiply.build(x=2, y=3)
 
     # Tuple with invalid type
@@ -79,7 +79,7 @@ def test_invalid_outputs():
     def add_multiply(x, y):
         return add(x, y).result, x * y
 
-    with pytest.raises(TypeError, match="Invalid output at"):
+    with pytest.raises(TypeError, match="Invalid graph return payload."):
         add_multiply.build(x=2, y=3)
 
 


### PR DESCRIPTION
This PR supports using the **Pydantic models or dataclass** to annotate the inputs/outputs spec. 

- By default, a ``BaseModel`` or ``dataclss`` expands to a **static namespace** with one socket per field.
- **dynamic** namespace, set ``model_config = {"extra": "allow"}`` and (optionally) ``"item_type"`` for the type of each dynamic value.
- Treat a model as a **single leaf**, set ``model_config = {"leaf": True}`` or use ``Leaf[YourModel]`` in the annotation.

Here is an example:
```python

from pydantic import BaseModel

class OutputsModel(BaseModel):
    sum: int
    product: int

@node
def add_multiply_pydantic_in_out(x, y) -> OutputsModel:
    return {'sum': x + y, 'product': x*y}

```

### Dynamic

```python
class DynamicOut(BaseModel):
    model_config = {"extra": "allow", "item_type": int}

    header: int = 42  # fixed (non-dynamic) field

@node
def make_dynamic_with_model(n: int) -> DynamicOut:
    # fixed field + dynamic keys with int values
    return {'header': 100, **{f'k{i}': i*i for i in range(n)}}

```

### Dataclass
```python

from dataclasses import dataclass

@dataclass
class OutputsModel:
    sum: int
    product: int

@node
def add_multiply_pydantic_in_out(x, y) -> OutputsModel:
    return {'sum': x + y, 'product': x*y}

```