### PR TITLE
Fix setting socket values

### DIFF
--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -671,7 +671,7 @@ class TaskSocket(BaseSocket, OperatorSocketMixin):
         elif isinstance(value, TaggedValue) and value._socket is not None:
             self._task.graph.add_link(value._socket, self)
         elif self.property:
-            if self._parent._name == "inputs" and any(
+            if self._full_name.split(".")[0] == "inputs" and any(
                 [
                     link.to_socket._full_name_with_task == self._full_name_with_task
                     for link in self._links

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -671,6 +671,21 @@ class TaskSocket(BaseSocket, OperatorSocketMixin):
         elif isinstance(value, TaggedValue) and value._socket is not None:
             self._task.graph.add_link(value._socket, self)
         elif self.property:
+
+            if (
+                self._parent._name == "inputs"
+                and self._links
+                and f"{self._task.name}.{self._name}"
+                not in [
+                    f"{link.from_task.name}.{link.from_socket._scoped_name}"
+                    for link in self._links
+                ]
+            ):
+                raise ValueError(
+                    f"Input {self._task.name}.{self._name} has already been set via a "
+                    f"link. Please update the linked value in {self._links}"
+                )
+
             self.property.value = value
         else:
             raise AttributeError(

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -672,17 +672,9 @@ class TaskSocket(BaseSocket, OperatorSocketMixin):
             self._task.graph.add_link(value._socket, self)
         elif self.property:
 
-            if (
-                self._parent._name == "inputs"
-                and self._links
-                and f"{self._task.name}.{self._name}"
-                not in [
-                    f"{link.from_task.name}.{link.from_socket._scoped_name}"
-                    for link in self._links
-                ]
-            ):
+            if any([link.to_socket._full_name_with_task == s._full_name_with_task for link in s._links]):
                 raise ValueError(
-                    f"Input {self._task.name}.{self._name} has already been set via a "
+                    f"Input {self._full_name_with_task} has already been set via a "
                     f"link. Please update the linked value in {self._links}"
                 )
 

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -671,8 +671,12 @@ class TaskSocket(BaseSocket, OperatorSocketMixin):
         elif isinstance(value, TaggedValue) and value._socket is not None:
             self._task.graph.add_link(value._socket, self)
         elif self.property:
-
-            if any([link.to_socket._full_name_with_task == s._full_name_with_task for link in s._links]):
+            if self._parent._name == "inputs" and any(
+                [
+                    link.to_socket._full_name_with_task == self._full_name_with_task
+                    for link in self._links
+                ]
+            ):
                 raise ValueError(
                     f"Input {self._full_name_with_task} has already been set via a "
                     f"link. Please update the linked value in {self._links}"

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -90,7 +90,6 @@ def test_bitwise_and_matmul_forbidden(future_socket, op):
 
 
 def test_function_like_ctxmgr_async_forbidden(future_socket):
-
     # context manager
     with pytest.raises(GraphDeferredIllegalOperationError):
         with future_socket:
@@ -444,27 +443,32 @@ def test_set_namespace_with_nested_key(task_with_namespace_socket):
 )
 def test_operation(op, name, ref_result, decorated_myadd):
     """Test socket operation."""
+    from typing import Any, Annotated
+
+    from node_graph import task, namespace
+    from node_graph.engine.local import LocalEngine
+
+    @task.graph()
+    def test_op() -> Annotated[
+        dict, namespace(result_1=Any, result_2=Any, result_3=Any)
+    ]:
+        socket_1 = decorated_myadd(2, 2).result
+        socket_2 = decorated_myadd(1, 1).result
+        result_1 = op(socket_1, socket_2)
+        assert isinstance(result_1, BaseSocket)
+        assert name in result_1._task.name
+        # test with non-socket value
+        result_2 = op(socket_1, 2)
+        # test reverse operation
+        result_3 = op(4, socket_2)
+        return {"result_1": result_1, "result_2": result_2, "result_3": result_3}
+
     print("decorated_myadd: ", decorated_myadd)
-    socket1 = decorated_myadd(2, 2)
-    socket2 = decorated_myadd(1, 1)
-    print("socket1:", socket1)
-    print("socket2:", socket2)
-    result = op(socket1, socket2)
-    assert isinstance(result, BaseSocket)
-    assert name in result._task.name
-    result._task.set_inputs({"x": 4, "y": 2})
-    result = result._task.execute()
-    assert result == ref_result
-    # test with non-socket value
-    result = op(socket1, 2)
-    result._task.inputs.x.value = 4
-    result = result._task.execute()
-    assert result == ref_result
-    # test reverse operation
-    result = op(4, socket2)
-    result._task.inputs.y.value = 2
-    result = result._task.execute()
-    assert result == ref_result
+    engine = LocalEngine()
+    result = engine.run(ng=test_op.build())
+    assert result["result_1"] == ref_result
+    assert result["result_2"] == ref_result
+    assert result["result_3"] == ref_result
 
 
 @pytest.mark.parametrize(
@@ -478,28 +482,34 @@ def test_operation(op, name, ref_result, decorated_myadd):
         (op.ne, "op_ne", True),
     ),
 )
-def test_operation_comparision(op, name, ref_result, decorated_myadd):
-    """Test socket comparision operation."""
-    socket1 = decorated_myadd(2, 2)
-    socket2 = decorated_myadd(1, 1)
-    result = op(socket1, socket2)
-    assert isinstance(result, BaseSocket)
-    assert name in result._task.name
-    result._task.set_inputs({"x": 4, "y": 2})
-    result = result._task.execute()
-    assert result == ref_result
-    # test with non-socket value
-    result = op(socket1, 2)
-    result._task.inputs.x.value = 4
-    result = result._task.execute()
-    assert result == ref_result
-    # test reverse operation
-    # note in the comparision operation, there is not reverse operation
-    # so the inputs.x will be always the socket
-    result = op(4, socket2)
-    result._task.inputs.x.value = 2
-    result = result._task.execute()
-    assert result == ref_result
+def test_operation_comparison(op, name, ref_result, decorated_myadd):
+    """Test socket comparison operation."""
+    from typing import Any, Annotated
+
+    from node_graph import task, namespace
+    from node_graph.engine.local import LocalEngine
+
+    @task.graph()
+    def test_op() -> Annotated[
+        dict, namespace(result_1=Any, result_2=Any, result_3=Any)
+    ]:
+        socket_1 = decorated_myadd(2, 2).result
+        socket_2 = decorated_myadd(1, 1).result
+        result_1 = op(socket_1, socket_2)
+        assert isinstance(result_1, BaseSocket)
+        assert name in result_1._task.name
+        # test with non-socket value
+        result_2 = op(socket_1, 2)
+        # test reverse operation
+        result_3 = op(4, socket_2)
+        return {"result_1": result_1, "result_2": result_2, "result_3": result_3}
+
+    print("decorated_myadd: ", decorated_myadd)
+    engine = LocalEngine()
+    result = engine.run(ng=test_op.build())
+    assert result["result_1"] == ref_result
+    assert result["result_2"] == ref_result
+    assert result["result_3"] == ref_result
 
 
 def test_unpacking():


### PR DESCRIPTION
Resolves #131

As discussed in the above issue, when tasks are run, their links are evaluated, which take precedence over input values directly set, leading to confusing behaviour where you can set and view values that are disregarded.

At the point where these values are set in `_set_socket_value`, it doesn't seem to be entirely straightforward to determine whether the update is being triggered by an update to the linked value, or if a value that should be linked is being directly set (and so ignored).

My solution has therefore been to check, for inputs, whether the input being changed corresponds to one in the socket links.

As discussed with @superstar54, the `test_operation` and `test_operation_comparison` were not testing quite what we expected, since `task.execute` does not resolve links, which meant that removing `result._task.set_inputs({"x": 4, "y": 2})` raises a key error.

I've updated these to run using a local engine, giving the expected behaviour, and added new tests that check that we can set unlinked values, but not linked values.