### PR TITLE
Property support wrapped values

### DIFF
--- a/docs/source/concept/property.rst
+++ b/docs/source/concept/property.rst
@@ -15,14 +15,14 @@ Data type
 
 Property can have different data type:
 
-- :class:`~node_graph.property.FloatProperty`
-- :class:`~node_graph.property.IntProperty`
-- :class:`~node_graph.property.BoolProperty`
-- :class:`~node_graph.property.StringProperty`
-- :class:`~node_graph.property.EnumProperty`
-- :class:`~node_graph.property.FloatVectorProperty`
-- :class:`~node_graph.property.IntVectorProperty`
-- :class:`~node_graph.property.BoolVectorProperty`
+- :class:`~node_graph.properties.builtins.PropertyFloat`
+- :class:`~node_graph.properties.builtins.PropertyInt`
+- :class:`~node_graph.properties.builtins.PropertyBool`
+- :class:`~node_graph.properties.builtins.PropertyString`
+- :class:`~node_graph.properties.builtins.PropertyEnum`
+- :class:`~node_graph.properties.builtins.PropertyFloatVector`
+- :class:`~node_graph.properties.builtins.PropertyIntVector`
+- :class:`~node_graph.properties.builtins.PropertyBoolVector`
 
 One can extend the property type by designing a custom property. Please read :ref:`custom_property` page for how to create a custom property type.
 
@@ -40,6 +40,32 @@ One can set the value of a property by:
    # or by
    float1.set_inputs({"Float": 2.0})
 
+Validation and wrapped values
+--------------------------------
+
+Each property type declares ``allowed_types`` and values are validated when assigned.
+
+In some runtimes, you may store values using wrapper objects (for example an ORM data node that exposes a Python value via ``.value``).
+To support this without hardcoding third-party dependencies, ``TaskProperty.validate`` accepts a value if any of these match ``allowed_types``:
+
+- the value itself
+- ``value.__wrapped__`` (if present)
+- ``value.value`` (if present)
+- values returned by any registered validation adapters
+
+External packages (e.g. an engine) can register adapters globally:
+
+.. code:: Python
+
+   from node_graph.property import TaskProperty
+
+   def unwrap_custom(value):
+       if hasattr(value, "get_list") and callable(value.get_list):
+           return value.get_list()
+       return TaskProperty.NOT_ADAPTED
+
+   TaskProperty.register_validation_adapter(unwrap_custom)
+
 
 Create properties for a new Task
 ----------------------------------------
@@ -47,7 +73,7 @@ Create properties for a new Task
 .. code:: Python
 
       def create_properties(self):
-         self.add_property("FloatVector", "x", size=3, default=[0, 0, 0])
+         self.add_property("node_graph.float_vector", "x", size=3, default=[0, 0, 0])
 
 Add properties to a input socket
 ----------------------------------------
@@ -56,7 +82,7 @@ Add properties to a input socket
 
       def update_spec(self):
          inp = self.add_input("node_graph.any", "x")
-         inp.add_property("FloatVector", size=3, default=[0, 0, 0])
+         inp.add_property("node_graph.float_vector", size=3, default=[0, 0, 0])
 
 Assigning to Existing Task
 --------------------------------
@@ -92,5 +118,5 @@ List of all Methods
 .. automodule:: node_graph.property
    :members:
 
-.. automodule:: node_graph.properties.built_in
+.. automodule:: node_graph.properties.builtins
    :members:

--- a/src/node_graph/__init__.py
+++ b/src/node_graph/__init__.py
@@ -1,7 +1,7 @@
 from .graph import Graph
 from .task import Task
 from .decorator import task
-from .knowledge_graph import KnowledgeGraph
+from .knowledge import KnowledgeGraph
 from .executor import SafeExecutor, RuntimeExecutor
 from .tasks import TaskPool
 from .collection import group

--- a/src/node_graph/graph.py
+++ b/src/node_graph/graph.py
@@ -12,7 +12,7 @@ from node_graph.link import TaskLink
 from node_graph.utils import yaml_to_dict
 from .config import BuiltinPolicy, BUILTIN_TASKS, MAX_LINK_LIMIT
 from .mixins import IOOwnerMixin, WidgetRenderableMixin
-from node_graph.knowledge_graph import KnowledgeGraph
+from node_graph.knowledge import KnowledgeGraph
 from dataclasses import dataclass
 from dataclasses import replace
 

--- a/src/node_graph/knowledge/__init__.py
+++ b/src/node_graph/knowledge/__init__.py
@@ -1,0 +1,3 @@
+from .graph import KnowledgeGraph
+
+__all__ = ["KnowledgeGraph"]

--- a/src/node_graph/knowledge/visualization.py
+++ b/src/node_graph/knowledge/visualization.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+from uuid import uuid4
+
+try:  # pragma: no cover - import guarded
+    from graphviz import Digraph
+except Exception:  # pragma: no cover - import guarded
+    Digraph = None
+
+
+def _require_graphviz() -> None:
+    if Digraph is None:
+        raise RuntimeError("graphviz is not installed; please `pip install graphviz`.")
+
+
+def to_graphviz(kg: Any) -> "Digraph":
+    """Render a KnowledgeGraph into a Graphviz Digraph."""
+    _require_graphviz()
+
+    rdf = kg.as_rdflib()
+    dot = Digraph(name="KnowledgeGraph")
+    node_ids: dict[Any, str] = {}
+
+    def _label(term: Any) -> str:
+        try:
+            return rdf.namespace_manager.normalizeUri(term)
+        except Exception:
+            return str(term)
+
+    def _node_id(term: Any) -> str:
+        if term not in node_ids:
+            node_ids[term] = f"n{len(node_ids)}"
+        return node_ids[term]
+
+    for subj, pred, obj in rdf:
+        s_id = _node_id(subj)
+        o_id = _node_id(obj)
+        dot.node(s_id, _label(subj))
+        dot.node(o_id, _label(obj))
+        dot.edge(s_id, o_id, label=_label(pred))
+    return dot
+
+
+def to_graphviz_svg(kg: Any) -> str:
+    """Return an SVG serialization of the knowledge graph via graphviz."""
+    graph = to_graphviz(kg)
+    return graph.pipe(format="svg").decode("utf-8")
+
+
+def _zoomable_html_fragment(
+    *,
+    container_id: str,
+    inner_id: str,
+    svg: str,
+    zoom_in_id: str,
+    zoom_out_id: str,
+    reset_id: str,
+    fullscreen_id: str,
+    container_class: str = "",
+    container_style: str = "",
+    viewport_class: str = "",
+    viewport_style: str = "",
+    controls_class: str = "",
+) -> str:
+    """Reusable HTML/JS snippet that wires zoom/fullscreen controls to a graph SVG."""
+    container_class_attr = f' class="{container_class}"' if container_class else ""
+    container_style_attr = f' style="{container_style}"' if container_style else ""
+    viewport_class_attr = f' class="{viewport_class}"' if viewport_class else ""
+    viewport_style_attr = f' style="{viewport_style}"' if viewport_style else ""
+    controls_class_attr = f' class="{controls_class}"' if controls_class else ""
+
+    return "\n".join(
+        [
+            f'<div id="{container_id}"{container_class_attr}{container_style_attr}>',
+            f"  <div{controls_class_attr}>",
+            f'    <button id="{zoom_in_id}" title="Zoom in">+</button>',
+            f'    <button id="{zoom_out_id}" title="Zoom out">-</button>',
+            f'    <button id="{reset_id}" title="Reset zoom">reset</button>',
+            f'    <button id="{fullscreen_id}" title="Fullscreen">fullscreen</button>',
+            "  </div>",
+            f'  <div id="{inner_id}"{viewport_class_attr}{viewport_style_attr}>{svg}</div>',
+            "</div>",
+            "<script>",
+            "  (function() {",
+            f"    const container = document.getElementById('{container_id}');",
+            f"    const viewport = document.getElementById('{inner_id}');",
+            f"    const btnIn = document.getElementById('{zoom_in_id}');",
+            f"    const btnOut = document.getElementById('{zoom_out_id}');",
+            f"    const btnReset = document.getElementById('{reset_id}');",
+            f"    const btnFs = document.getElementById('{fullscreen_id}');",
+            "    let kgScale = 1;",
+            "    const clamp = (val) => Math.min(4, Math.max(0.25, val));",
+            "    const apply = () => { viewport.style.transform = `scale(${kgScale})`; };",
+            "    const setScale = (val) => { kgScale = clamp(val); apply(); };",
+            "    const onWheel = (ev) => {",
+            "      if (!ev.ctrlKey) return;",
+            "      ev.preventDefault();",
+            "      const factor = ev.deltaY < 0 ? 1.1 : 1/1.1;",
+            "      const prev = kgScale;",
+            "      setScale(kgScale * factor);",
+            "      const rect = viewport.getBoundingClientRect();",
+            "      const offsetX = ev.clientX - rect.left;",
+            "      const offsetY = ev.clientY - rect.top;",
+            "      const ratio = kgScale / prev;",
+            "      container.scrollLeft = offsetX * (ratio - 1) + container.scrollLeft;",
+            "      container.scrollTop = offsetY * (ratio - 1) + container.scrollTop;",
+            "    };",
+            "    container.addEventListener('wheel', onWheel, { passive: false });",
+            "    btnIn.onclick = () => setScale(kgScale * 1.2);",
+            "    btnOut.onclick = () => setScale(kgScale / 1.2);",
+            "    btnReset.onclick = () => setScale(1);",
+            "    btnFs.onclick = () => {",
+            "      if (!document.fullscreenElement) {",
+            "        container.requestFullscreen?.();",
+            "      } else {",
+            "        document.exitFullscreen?.();",
+            "      }",
+            "    };",
+            "    apply();",
+            "  })();",
+            "</script>",
+        ]
+    )
+
+
+def _control_ids(container_id: str) -> tuple[str, str, str, str, str]:
+    inner_id = f"{container_id}-inner"
+    zoom_in_id = f"{container_id}-zin"
+    zoom_out_id = f"{container_id}-zout"
+    reset_id = f"{container_id}-reset"
+    fullscreen_id = f"{container_id}-fs"
+    return inner_id, zoom_in_id, zoom_out_id, reset_id, fullscreen_id
+
+
+def repr_html(kg: Any) -> Optional[str]:
+    """IPython/Jupyter HTML repr hook."""
+    try:
+        svg = to_graphviz_svg(kg)
+    except RuntimeError:
+        return None
+
+    container_id = f"kg-{kg.graph_uuid or uuid4()}"
+    inner_id, zoom_in_id, zoom_out_id, reset_id, fullscreen_id = _control_ids(
+        container_id
+    )
+    fragment = _zoomable_html_fragment(
+        container_id=container_id,
+        inner_id=inner_id,
+        svg=svg,
+        zoom_in_id=zoom_in_id,
+        zoom_out_id=zoom_out_id,
+        reset_id=reset_id,
+        fullscreen_id=fullscreen_id,
+        container_class="node-graph-knowledge-graph",
+        container_style="overflow:auto; position:relative;",
+        viewport_style="transform-origin: top left; display:inline-block;",
+        controls_class="node-graph-kg-controls",
+    )
+    return "\n".join(
+        [
+            "<style>",
+            f"  #{container_id}, #{container_id} svg {{ background: #ffffff; }}",
+            f"  #{container_id}:fullscreen {{ background: #ffffff; }}",
+            "</style>",
+            fragment,
+        ]
+    )
+
+
+def to_html(kg: Any, *, title: Optional[str] = None) -> str:
+    """Return an HTML document embedding the knowledge graph SVG."""
+    svg = to_graphviz_svg(kg)
+    page_title = title or f"{kg.graph_uuid or 'Graph'} knowledge graph"
+    container_id = f"kg-{kg.graph_uuid or uuid4()}"
+    inner_id, zoom_in_id, zoom_out_id, reset_id, fullscreen_id = _control_ids(
+        container_id
+    )
+    fragment = _zoomable_html_fragment(
+        container_id=container_id,
+        inner_id=inner_id,
+        svg=svg,
+        zoom_in_id=zoom_in_id,
+        zoom_out_id=zoom_out_id,
+        reset_id=reset_id,
+        fullscreen_id=fullscreen_id,
+        container_class="kg-container",
+        container_style="overflow:auto;",
+        viewport_class="kg-viewport",
+        controls_class="kg-controls",
+    )
+    return """<!DOCTYPE html>\n""" + "\n".join(
+        [
+            '<html lang="en">',
+            "  <head>",
+            '    <meta charset="utf-8" />',
+            f"    <title>{page_title}</title>",
+            "    <style>",
+            "      body {",
+            "        font-family: Helvetica, Arial, sans-serif;",
+            "        background-color: #f9f9fb;",
+            "        margin: 0;",
+            "        padding: 1.5rem;",
+            "        color: #212121;",
+            "      }",
+            "      .container {",
+            "        background-color: #ffffff;",
+            "        padding: 1.5rem;",
+            "        border-radius: 12px;",
+            "        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);",
+            "        overflow: auto;",
+            "        position: relative;",
+            "        min-height: 60vh;",
+            "      }",
+            "      .kg-container { background: #ffffff; }",
+            "      .kg-container:fullscreen { background: #ffffff; }",
+            "      .kg-container svg { background: #ffffff; }",
+            "      h1 {",
+            "        font-size: 1.5rem;",
+            "        margin-top: 0;",
+            "        margin-bottom: 1rem;",
+            "      }",
+            "      svg {",
+            "        height: auto;",
+            "      }",
+            "      .kg-controls {",
+            "        display: flex;",
+            "        gap: 0.5rem;",
+            "        margin-bottom: 0.75rem;",
+            "        flex-wrap: wrap;",
+            "      }",
+            "      .kg-controls button {",
+            "        padding: 0.35rem 0.75rem;",
+            "        border-radius: 6px;",
+            "        border: 1px solid #e0e0e0;",
+            "        background: #fafafa;",
+            "        cursor: pointer;",
+            "      }",
+            "      .kg-controls button:hover {",
+            "        background: #f1f1f1;",
+            "      }",
+            "      .kg-viewport {",
+            "        transform-origin: top left;",
+            "        display: inline-block;",
+            "      }",
+            "    </style>",
+            "  </head>",
+            "  <body>",
+            '    <div class="container">',
+            f"      <h1>{page_title}</h1>",
+            f"      {fragment}",
+            "    </div>",
+            "  </body>",
+            "</html>",
+        ]
+    )
+
+
+def save_html(kg: Any, path: str, *, title: Optional[str] = None) -> str:
+    """Serialize the HTML view to ``path`` and return the resolved path."""
+    html = to_html(kg, title=title)
+    path_obj = Path(path)
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    path_obj.write_text(html, encoding="utf-8")
+    return str(path_obj)

--- a/src/node_graph/properties/builtins.py
+++ b/src/node_graph/properties/builtins.py
@@ -118,22 +118,25 @@ class PropertyVector(TaskProperty, SerializeJson):
 
     def validate(self, value: Any) -> None:
         """Validate the given value based on allowed types."""
-        if value is not None:
-            if len(value) != self.size:
+        seq = self._select_validation_candidate(value)
+        if seq is not None:
+            if len(seq) != self.size:
                 raise ValueError(
-                    f"Invalid size: Expected {self.size}, got {len(value)} instead."
+                    f"Invalid size: Expected {self.size}, got {len(seq)} instead."
                 )
-            for v in value:
+            for v in seq:
                 self.validate_item(v)
 
         return super().validate(value)
 
     def validate_item(self, value: Any) -> None:
         """Validate the given value based on allowed types."""
-        if not isinstance(value, self.allowed_item_types):
-            raise TypeError(
-                f"Expected value of type {self.allowed_item_types}, got {type(value).__name__} instead."
-            )
+        for candidate in self._iter_validation_candidates(value):
+            if isinstance(candidate, self.allowed_item_types):
+                return
+        raise TypeError(
+            f"Expected value of type {self.allowed_item_types}, got {type(value).__name__} instead."
+        )
 
     def set_value(self, value: Any) -> None:
         self.validate(value)
@@ -204,22 +207,25 @@ class MatrixProperty(TaskProperty, SerializeJson):
     def validate(self, value: Any) -> None:
         """Validate the given value based on allowed types."""
         length = self.size[0] * self.size[1]
-        if value is not None:
-            if not (len(value) == length):
+        seq = self._select_validation_candidate(value)
+        if seq is not None:
+            if not (len(seq) == length):
                 raise ValueError(
-                    f"Invalid size: Expected {length}, got {len(value)} instead."
+                    f"Invalid size: Expected {length}, got {len(seq)} instead."
                 )
-            for v in value:
+            for v in seq:
                 self.validate_item(v)
 
         return super().validate(value)
 
     def validate_item(self, value: Any) -> None:
         """Validate the given value based on allowed types."""
-        if not isinstance(value, self.allowed_item_types):
-            raise TypeError(
-                f"Expected value of type {self.allowed_item_types}, got {type(value).__name__} instead."
-            )
+        for candidate in self._iter_validation_candidates(value):
+            if isinstance(candidate, self.allowed_item_types):
+                return
+        raise TypeError(
+            f"Expected value of type {self.allowed_item_types}, got {type(value).__name__} instead."
+        )
 
     def copy(self):
         p = self.__class__(

--- a/src/node_graph/semantics.py
+++ b/src/node_graph/semantics.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from node_graph.socket import BaseSocket, TaggedValue
 from node_graph.socket_spec import SocketSpec
+from node_graph.utils.json_utils import json_ready
 
 DEFAULT_NAMESPACE_REGISTRY: Dict[str, str] = {
     "qudt": "http://qudt.org/schema/qudt/",
@@ -89,21 +90,7 @@ class SemanticTag(BaseModel):
 def _json_ready(value: Any) -> Any:
     """Convert semantics payloads into JSON-serialisable structures."""
 
-    if is_dataclass(value):
-        return _json_ready(asdict(value))
-    if isinstance(value, BaseModel):
-        return _json_ready(value.model_dump(exclude_none=True))
-    if isinstance(value, Enum):
-        return _json_ready(value.value)
-    if isinstance(value, Mapping):
-        return {k: _json_ready(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple, set)):
-        return [_json_ready(v) for v in value]
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    return repr(value)
+    return json_ready(value)
 
 
 def _detect_prefixes(value: Any) -> Set[str]:

--- a/src/node_graph/utils/json_utils.py
+++ b/src/node_graph/utils/json_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def json_ready(value: Any) -> Any:
+    """Convert a value into a JSON-serialisable structure."""
+
+    if is_dataclass(value):
+        return json_ready(asdict(value))
+    if isinstance(value, BaseModel):
+        return json_ready(value.model_dump(exclude_none=True))
+    if isinstance(value, Enum):
+        return json_ready(value.value)
+    if isinstance(value, dict):
+        return {str(k): json_ready(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [json_ready(v) for v in value]
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return repr(value)
+
+
+def stable_json_dumps(value: Any) -> str:
+    """Return a stable JSON string for hashing/deduplication."""
+
+    try:
+        return json.dumps(value, sort_keys=True, default=str)
+    except Exception:
+        return repr(value)
+
+
+def hashable_signature(value: Any) -> Any:
+    """Return a hashable representation of a JSON-ready object."""
+
+    if isinstance(value, (dict, list)):
+        return stable_json_dumps(value)
+    return value
+
+
+def triple_signature(triple: Any) -> tuple[Any, ...]:
+    """Return a hashable signature for triple-like objects.
+
+    This is used for deduplicating triples where the object might be a list/dict
+    (i.e. JSON-ready but not hashable).
+    """
+    if isinstance(triple, (list, tuple)) and len(triple) == 3:
+        subject, predicate, obj = triple
+        return (subject, predicate, hashable_signature(obj))
+    if isinstance(triple, (list, tuple)):
+        return tuple(hashable_signature(value) for value in triple)
+    return (hashable_signature(triple),)

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -6,7 +6,7 @@ from rdflib.namespace import RDFS
 
 from node_graph import Graph, namespace, task
 from node_graph.socket_spec import meta
-from node_graph.knowledge_graph import KnowledgeGraph
+from node_graph.knowledge import KnowledgeGraph
 from node_graph.semantics import (
     SemanticsAnnotation,
     SemanticsPayload,

--- a/tests/test_property_validation.py
+++ b/tests/test_property_validation.py
@@ -1,0 +1,26 @@
+from node_graph.property import TaskProperty
+from node_graph.properties.builtins import PropertyIntVector
+
+
+class GetListWrapper:
+    def __init__(self, values):
+        self._values = list(values)
+
+    def get_list(self):
+        return list(self._values)
+
+
+def test_validation_adapter_allows_custom_unwrap():
+    def unwrap_get_list(value):
+        if hasattr(value, "get_list") and callable(value.get_list):
+            return value.get_list()
+        return TaskProperty.NOT_ADAPTED
+
+    TaskProperty.register_validation_adapter(unwrap_get_list)
+    try:
+        prop = PropertyIntVector(name="v", size=3)
+        wrapped = GetListWrapper([1, 2, 3])
+        prop.value = wrapped
+        assert prop.value is wrapped
+    finally:
+        TaskProperty.unregister_validation_adapter(unwrap_get_list)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -446,7 +446,6 @@ def test_operation(op, name, ref_result, decorated_myadd):
     from typing import Any, Annotated
 
     from node_graph import task, namespace
-    from node_graph.engine.local import LocalEngine
 
     @task.graph()
     def test_op() -> Annotated[
@@ -457,18 +456,17 @@ def test_operation(op, name, ref_result, decorated_myadd):
         result_1 = op(socket_1, socket_2)
         assert isinstance(result_1, BaseSocket)
         assert name in result_1._task.name
+        assert result_1._task.get_executor().module_path == "node_graph.socket"
+        assert result_1._task.get_executor().callable_name == name
         # test with non-socket value
         result_2 = op(socket_1, 2)
+        assert isinstance(result_2, BaseSocket)
         # test reverse operation
         result_3 = op(4, socket_2)
+        assert isinstance(result_3, BaseSocket)
         return {"result_1": result_1, "result_2": result_2, "result_3": result_3}
 
-    print("decorated_myadd: ", decorated_myadd)
-    engine = LocalEngine()
-    result = engine.run(ng=test_op.build())
-    assert result["result_1"] == ref_result
-    assert result["result_2"] == ref_result
-    assert result["result_3"] == ref_result
+    test_op.build()
 
 
 @pytest.mark.parametrize(
@@ -487,7 +485,6 @@ def test_operation_comparison(op, name, ref_result, decorated_myadd):
     from typing import Any, Annotated
 
     from node_graph import task, namespace
-    from node_graph.engine.local import LocalEngine
 
     @task.graph()
     def test_op() -> Annotated[
@@ -498,18 +495,17 @@ def test_operation_comparison(op, name, ref_result, decorated_myadd):
         result_1 = op(socket_1, socket_2)
         assert isinstance(result_1, BaseSocket)
         assert name in result_1._task.name
+        assert result_1._task.get_executor().module_path == "node_graph.socket"
+        assert result_1._task.get_executor().callable_name == name
         # test with non-socket value
         result_2 = op(socket_1, 2)
+        assert isinstance(result_2, BaseSocket)
         # test reverse operation
         result_3 = op(4, socket_2)
+        assert isinstance(result_3, BaseSocket)
         return {"result_1": result_1, "result_2": result_2, "result_3": result_3}
 
-    print("decorated_myadd: ", decorated_myadd)
-    engine = LocalEngine()
-    result = engine.run(ng=test_op.build())
-    assert result["result_1"] == ref_result
-    assert result["result_2"] == ref_result
-    assert result["result_3"] == ref_result
+    test_op.build()
 
 
 def test_invalid_input(decorated_myadd):

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,4 +1,5 @@
 from node_graph import Graph
+from pathlib import Path
 import yaml
 
 
@@ -12,7 +13,8 @@ def test_export_yaml(ng):
 
 def test_load_yaml_file():
     """Test yaml"""
-    ng = Graph.from_yaml("datas/test_yaml.yaml")
+    yaml_path = Path(__file__).parent / "datas" / "test_yaml.yaml"
+    ng = Graph.from_yaml(str(yaml_path))
     assert len(ng.tasks) == 5
     assert ng.tasks.float1.inputs.value.value == 2.0
     assert ng.tasks.add1.inputs.y.value == 3.0


### PR DESCRIPTION
Each property type declares ``allowed_types`` and values are validated when assigned.

In some runtimes, users may store values using wrapper objects (for example an ORM data node that exposes a Python value via ``.value``).
To support this without hardcoding third-party dependencies, ``TaskProperty.validate`` accepts a value if any of these match ``allowed_types``:

- the value itself
- ``value.__wrapped__`` (if present)
- ``value.value`` (if present)
- values returned by any registered validation adapters

External packages (e.g. an engine) can register adapters globally:

```python

   from node_graph.property import TaskProperty

   def unwrap_custom(value):
       if hasattr(value, "get_list") and callable(value.get_list):
           return value.get_list()
       return TaskProperty.NOT_ADAPTED

   TaskProperty.register_validation_adapter(unwrap_custom)
```
