### PR TITLE
Add socket `value_source` flag

### DIFF
--- a/src/node_graph/engine/base.py
+++ b/src/node_graph/engine/base.py
@@ -56,16 +56,16 @@ class BaseEngine(ABC):
             sub_ng = self._build_subgraph(task, graph_fn, kwargs)
             parent_pid = self._get_active_graph_pid()
             self._run_subgraph(task, sub_ng, parent_pid)
-            return sub_ng.outputs._collect_values(raw=False)
+            return sub_ng.outputs._collect_values(unwrap=False)
 
         return _graph_runner
 
     @staticmethod
     def _snapshot_builtins(ng: Graph) -> Dict[str, Dict[str, Any]]:
         return {
-            "graph_ctx": ng.ctx._collect_values(raw=False),
-            "graph_inputs": ng.inputs._collect_values(raw=False),
-            "graph_outputs": ng.outputs._collect_values(raw=False),
+            "graph_ctx": ng.ctx._collect_values(unwrap=False),
+            "graph_inputs": ng.inputs._collect_values(unwrap=False),
+            "graph_outputs": ng.outputs._collect_values(unwrap=False),
         }
 
     def _graph_flow_run_id(self, ng: Graph) -> str:
@@ -88,7 +88,7 @@ class BaseEngine(ABC):
             parent_pid=parent_pid,
         )
         self.recorder.record_inputs_payload(
-            graph_pid, ng.inputs._collect_values(raw=False)
+            graph_pid, ng.inputs._collect_values(unwrap=False)
         )
         return graph_pid
 
@@ -130,7 +130,7 @@ class BaseEngine(ABC):
                     f"Failed to parse outputs for task '{task.name}': {e}"
                 ) from e
         tag_socket_value(task.outputs, only_uuid=True)
-        return task.outputs._collect_values(raw=False)
+        return task.outputs._collect_values(unwrap=False)
 
     def _link_socket_value(
         self, from_name: str, from_socket: str, source_map: Dict[str, Any]

--- a/src/node_graph/socket_meta.py
+++ b/src/node_graph/socket_meta.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Mapping, Optional
 
+UPDATABLE_SOCKET_META_FIELDS = {"value_source"}
+
 
 class CallRole(str, Enum):
     """Defines how a socket's value is used in a function call."""

--- a/src/node_graph/utils/graph.py
+++ b/src/node_graph/utils/graph.py
@@ -170,7 +170,7 @@ def materialize_graph(
         inputs = clean_socket_reference(inputs)
         graph.graph_inputs.set_inputs(inputs)
         tag_socket_value(graph.inputs)
-        inputs = graph.inputs._collect_values(raw=False)
+        inputs = graph.inputs._collect_values(unwrap=False)
         raw = func(**inputs)
         _assign_graph_outputs(raw, graph)
         tag_socket_value(graph.inputs, only_uuid=True)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -711,7 +711,7 @@ def test_tagged_value():
     # assign the value to another socket
     n1 = ng.add_task(Task, "test1")
     s1 = TaskSocketNamespace("inputs", task=n1, graph=ng, metadata={"dynamic": True})
-    s1._set_socket_value(s._collect_values(raw=False))
+    s1._set_socket_value(s._collect_values(unwrap=False))
     # this will add link between the two sockets, instead of copying the value
     assert len(ng.links) == 4
     assert "test.a -> test1.a" in ng.links


### PR DESCRIPTION
- value_source: `link` | `property`
- Default stays `link` (current behavior).
- When set to `property`, skip link resolution and use the property value.