### PR TITLE
Fix the `_task_input_resolver`

### DIFF
--- a/src/node_graph/task.py
+++ b/src/node_graph/task.py
@@ -491,7 +491,11 @@ class Task(WidgetRenderableMixin, IOOwnerMixin, WaitableMixin):
         else:
             raw_value = socket._value
 
-        links = getattr(socket, "_links", [])
+        links = [
+            link
+            for link in getattr(socket, "_links", [])
+            if getattr(link, "to_socket", None) is socket
+        ]
         if not links:
             return raw_value
 

--- a/src/node_graph/task.py
+++ b/src/node_graph/task.py
@@ -516,9 +516,9 @@ class Task(WidgetRenderableMixin, IOOwnerMixin, WaitableMixin):
             from_socket = lk.from_socket
             key = f"{lk.from_task.name}_{from_socket._scoped_name}"
             if from_socket._scoped_name == "_outputs":
-                bundle[key] = from_socket._task.outputs._collect_values(esolve=False)
+                bundle[key] = from_socket._task.outputs._collect_values(resolve=False)
             elif isinstance(from_socket, TaskSocketNamespace):
-                bundle[key] = from_socket._collect_values(esolve=False)
+                bundle[key] = from_socket._collect_values(resolve=False)
             else:
                 bundle[key] = from_socket._value
         return bundle or raw_value

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -152,3 +152,14 @@ def test_dynamic_outputs():
         match="Output socket name 'x' not declared in Graph task outputs.",
     ):
         graph = test_graph.build(x=2, y=3)
+
+
+def test_graph_inputs_value():
+    @task.graph()
+    def test_graph(x, y):
+        add(x, y)
+        add(x, y)
+
+    graph = test_graph.build(x=2, y=3)
+    assert graph.inputs.x.value == 2
+    assert graph.inputs.y.value == 3

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -119,15 +119,6 @@ def test_clear_updatable_meta_clears_value_source():
     assert "value_source" not in inputs.x._metadata.extras
 
 
-def test_default_input_resolver_ignores_from_socket_links():
-    ng = Graph(name="test_input_resolver_direction")
-    add1 = ng.add_task(test_add, "add1")
-    add2 = ng.add_task(test_add, "add2")
-    add2.set_inputs({"x": add1.outputs.result})
-    add1.outputs.result.value = 4
-    assert add1.outputs.result.value == 4
-
-
 def test_set_non_exit_input_for_dynamic_input():
     task = Task()
     task.inputs._metadata.dynamic = True

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -119,6 +119,15 @@ def test_clear_updatable_meta_clears_value_source():
     assert "value_source" not in inputs.x._metadata.extras
 
 
+def test_default_input_resolver_ignores_from_socket_links():
+    ng = Graph(name="test_input_resolver_direction")
+    add1 = ng.add_task(test_add, "add1")
+    add2 = ng.add_task(test_add, "add2")
+    add2.set_inputs({"x": add1.outputs.result})
+    add1.outputs.result.value = 4
+    assert add1.outputs.result.value == 4
+
+
 def test_set_non_exit_input_for_dynamic_input():
     task = Task()
     task.inputs._metadata.dynamic = True


### PR DESCRIPTION
`_default_input_resolver` should only consider links where the socket is the to_socket