### PR TITLE
Improve pydantic model and dataclass usage

### DIFF
--- a/docs/gallery/autogen/annotate_inputs_outputs.py
+++ b/docs/gallery/autogen/annotate_inputs_outputs.py
@@ -294,7 +294,8 @@ wg.engine.recorder
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Sometimes you want to **validate** with a Pydantic model but store it as a **single node** instead
-# of expanding fields.
+# of expanding fields. For leaf models, the value is treated as a blob; the socket stays annotated
+# and the object is stored as-is.
 # There are two ways:
 #
 # 1) Mark the model: ``model_config = {"leaf": True}``
@@ -311,7 +312,7 @@ class BlobModel(BaseModel):
 @task()
 def consume_blob(m: BlobModel) -> dict:
     # 'm' is validated by Pydantic but stored/treated as one leaf node
-    return {"sum": m["a"] + m["b"]}
+    return {"sum": m.a + m.b}
 
 
 # Per-use override without modifying the model:
@@ -322,13 +323,13 @@ class AnotherModel(BaseModel):
 
 @task()
 def consume_blob_per_use(m: Leaf[AnotherModel]) -> dict:
-    return {"sum": m["a"] + m["b"]}
+    return {"sum": m.a + m.b}
 
 
 @task.graph()
 def BlobExamples():
-    consume_blob(m={"a": 1, "b": 2})
-    consume_blob_per_use(m={"a": 3, "b": 4})
+    consume_blob(m=BlobModel(a=1, b=2))
+    consume_blob_per_use(m=AnotherModel(a=3, b=4))
 
 
 wg = BlobExamples.build()

--- a/docs/gallery/autogen/annotate_inputs_outputs.py
+++ b/docs/gallery/autogen/annotate_inputs_outputs.py
@@ -388,16 +388,14 @@ wg.engine.recorder
 # %%
 # .. important::
 #
-#    Models/dataclasses are annotation-only
-#    Even when you annotate with BaseModel or @dataclass, do not pass instances of these types to
-#    tasks/graphs. Always pass plain dictionaries:
+#    Structured models (Pydantic or dataclasses) are supported as *runtime* values.
+#    You may pass instances to tasks/graphs and return them from tasks:
 #
-#    - This lets Graph expand inputs/outputs into individual sockets, so it can wire provenance
-#      edges precisely (e.g., data.x --> task.data.x).
-#    - It allows graph inputs to be collected from task outputs as a dict of AiiDA ORM nodes,
+#    - Instances are expanded to plain dicts when assigned to namespace sockets, so Graph can wire
+#      provenance edges precisely (e.g., data.x --> task.data.x).
+#    - Graph inputs can still be collected from task outputs as a dict of AiiDA ORM nodes,
 #      preserving AiiDA links between nodes.
-#    - Validation still happens via the Graph spec (derived from your annotations)--you’re
-#      just not constructing runtime model/dataclass objects.
+#    - Validation still happens via the Graph spec (derived from your annotations).
 #
 # Data linkage
 # ------------

--- a/src/node_graph/engine/local.py
+++ b/src/node_graph/engine/local.py
@@ -12,6 +12,7 @@ from .utils import (
     update_nested_dict_with_special_keys,
     _resolve_tagged_value,
 )
+from node_graph.utils.struct_utils import coerce_inputs_from_spec
 
 
 class LocalEngine(BaseEngine):
@@ -99,6 +100,7 @@ class LocalEngine(BaseEngine):
 
             try:
                 raw_kwargs = _resolve_tagged_value(run_kwargs)
+                raw_kwargs = coerce_inputs_from_spec(raw_kwargs, task.spec.inputs)
                 if is_graph and fn is not None:
                     res = fn(**run_kwargs)
                 elif fn is None:

--- a/src/node_graph/engine/utils.py
+++ b/src/node_graph/engine/utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict, deque
 from node_graph.link import TaskLink
 from node_graph import Graph
 from node_graph.socket_spec import SocketSpec
+from node_graph.utils.struct_utils import is_structured_instance, structured_to_dict
 
 
 def get_nested_dict(d: Dict, name: str, **kwargs) -> Any:
@@ -259,6 +260,8 @@ def parse_outputs(
     """
     fields = spec.fields or {}
     is_dyn = bool(spec.dynamic)
+    if is_structured_instance(results) and (fields or is_dyn):
+        results = structured_to_dict(results)
 
     # tuple -> map by order of fixed field names
     if isinstance(results, tuple):

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -8,6 +8,7 @@ from dataclasses import MISSING, replace
 from node_graph.orm.mapping import type_mapping
 from node_graph.socket_meta import SocketMeta, UPDATABLE_SOCKET_META_FIELDS
 from node_graph.registry import EntryPointPool
+from node_graph.utils.struct_utils import is_structured_instance, structured_to_dict
 import wrapt
 
 if TYPE_CHECKING:
@@ -1159,6 +1160,8 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
 
         if value is None:
             return
+        if is_structured_instance(value):
+            value = structured_to_dict(value)
 
         # Link another socket directly to this namespace
         if isinstance(value, BaseSocket):
@@ -1283,6 +1286,8 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
             # Now we’re guaranteed the key exists; delegate appropriately
             target = self._sockets[key]
             if isinstance(target, TaskSocketNamespace):
+                if is_structured_instance(val):
+                    val = structured_to_dict(val)
                 # If incoming val is a dict, recurse. If it’s a socket, link to the namespace.
                 if isinstance(val, dict):
                     target._set_socket_value(val, value_source=value_source)

--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -555,7 +555,7 @@ class SocketSpecAPI:
                 # Pydantic model
                 leaf_override = _annot_is_leaf_marker(T)
                 if leaf_override is not None and _is_struct_model_type(leaf_override):
-                    child = cls._leaf_from_type(dict)
+                    child = cls._leaf_from_type(leaf_override)
                 elif _is_struct_model_type(base_T):
                     child = cls.from_model(base_T)
                 elif isinstance(base_T, SocketSpec):
@@ -596,7 +596,7 @@ class SocketSpecAPI:
         # Pydantic model
         leaf_override = _annot_is_leaf_marker(item_type)
         if leaf_override is not None and _is_struct_model_type(leaf_override):
-            item_spec = cls._leaf_from_type(dict)
+            item_spec = cls._leaf_from_type(leaf_override)
         elif _is_struct_model_type(T):
             item_spec = cls.from_model(T)
         else:
@@ -645,7 +645,8 @@ class SocketSpecAPI:
 
         # Leaf override (config or Leaf[...] handled earlier)
         if _struct_is_leaf(model_cls):
-            return cls._leaf_from_type(dict)
+            leaf_target = _annot_is_leaf_marker(model_cls)
+            return cls._leaf_from_type(leaf_target or model_cls)
 
         # Build fields + defaults via a unified path
         if _is_pydantic_model_type(model_cls):
@@ -784,7 +785,7 @@ class SocketSpecAPI:
         # Leaf[...] override
         leaf_target = _annot_is_leaf_marker(ann)
         if leaf_target is not None:
-            return cls._leaf_from_type(dict)
+            return cls._leaf_from_type(leaf_target)
 
         base_T, _ = _unwrap_annotated(ann)
         base_T = _strip_optional(base_T)
@@ -854,7 +855,7 @@ class SocketSpecAPI:
         # Pydantic model?
         leaf_override = _annot_is_leaf_marker(T)
         if leaf_override is not None and _is_struct_model_type(leaf_override):
-            return cls._leaf_from_type(dict)
+            return cls._leaf_from_type(leaf_override)
         if _is_struct_model_type(base_T):
             return cls.from_model(base_T)
 
@@ -919,7 +920,7 @@ class SocketSpecAPI:
                 # Pydantic-aware leaf override?
                 leaf_override = _annot_is_leaf_marker(T)
                 if leaf_override is not None and _is_struct_model_type(leaf_override):
-                    spec = cls._leaf_from_type(dict)
+                    spec = cls._leaf_from_type(leaf_override)
                 # Pydantic model?
                 elif _is_struct_model_type(base_T):
                     spec = cls.from_model(base_T)
@@ -969,7 +970,11 @@ class SocketSpecAPI:
             # Apply selection/transform directives from Annotated
             spec = _apply_select_from_annotation(T, spec)
 
-            if _is_struct_model_type(base_T) and _annot_is_leaf_marker(T) is None:
+            if (
+                _is_struct_model_type(base_T)
+                and _annot_is_leaf_marker(T) is None
+                and not _struct_is_leaf(base_T)
+            ):
                 info = structured_type_info(base_T)
                 if info is not None and "structured_type" not in spec.meta.extras:
                     spec = replace(
@@ -1065,7 +1070,7 @@ class SocketSpecAPI:
         # Leaf override for Pydantic
         leaf_override = _annot_is_leaf_marker(ret)
         if leaf_override is not None and _is_struct_model_type(leaf_override):
-            return cls._wrap_leaf_as_ns(cls._leaf_from_type(dict))
+            return cls._wrap_leaf_as_ns(cls._leaf_from_type(leaf_override))
 
         # Fallbacks
         if ret is None or ret is inspect._empty:

--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -13,6 +13,7 @@ import inspect
 from copy import deepcopy
 from node_graph.orm.mapping import type_mapping as DEFAULT_TM
 from node_graph.socket_meta import CallRole, SocketMeta, merge_meta
+from node_graph.utils.struct_utils import structured_type_info
 from .socket import TaskSocketNamespace
 import ast
 import textwrap
@@ -967,6 +968,16 @@ class SocketSpecAPI:
 
             # Apply selection/transform directives from Annotated
             spec = _apply_select_from_annotation(T, spec)
+
+            if _is_struct_model_type(base_T) and _annot_is_leaf_marker(T) is None:
+                info = structured_type_info(base_T)
+                if info is not None and "structured_type" not in spec.meta.extras:
+                    spec = replace(
+                        spec,
+                        meta=merge_meta(
+                            spec.meta, SocketMeta(extras={"structured_type": info})
+                        ),
+                    )
 
             # Defaults: scalar -> leaf default; dict -> traverse into leaves
             if param.default is not inspect._empty and param.default is not None:

--- a/src/node_graph/utils/graph.py
+++ b/src/node_graph/utils/graph.py
@@ -150,6 +150,7 @@ def materialize_graph(
     assign its outputs and return the Graph.
     """
     from node_graph.utils import tag_socket_value, clean_socket_reference
+    from node_graph.utils.struct_utils import coerce_inputs_from_spec
     from node_graph.utils.function import (
         prepare_function_inputs,
         inspect_callable_metadata,
@@ -171,6 +172,7 @@ def materialize_graph(
         graph.graph_inputs.set_inputs(inputs)
         tag_socket_value(graph.inputs)
         inputs = graph.inputs._collect_values(unwrap=False)
+        inputs = coerce_inputs_from_spec(inputs, in_spec)
         raw = func(**inputs)
         _assign_graph_outputs(raw, graph)
         tag_socket_value(graph.inputs, only_uuid=True)

--- a/src/node_graph/utils/struct_utils.py
+++ b/src/node_graph/utils/struct_utils.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict
+import importlib
+
+from pydantic import BaseModel
+
+
+def is_structured_instance(value: Any) -> bool:
+    """Return True for dataclass or Pydantic model instances."""
+    return (is_dataclass(value) and not isinstance(value, type)) or isinstance(
+        value, BaseModel
+    )
+
+
+def structured_to_dict(value: Any) -> Any:
+    """Convert structured instances to plain dicts for namespace wiring."""
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, BaseModel):
+        if contains_tagged_value(value):
+            return {
+                name: structured_to_dict(getattr(value, name))
+                for name in value.model_fields
+            }
+        return value.model_dump(exclude_none=False)
+    return value
+
+
+def structured_type_info(tp: Any) -> Dict[str, str] | None:
+    """Return a serializable descriptor for structured types."""
+    if is_dataclass(tp):
+        return {"kind": "dataclass", "path": structured_type_path(tp)}
+    if isinstance(tp, type) and issubclass(tp, BaseModel):
+        return {"kind": "pydantic", "path": structured_type_path(tp)}
+    return None
+
+
+def structured_type_path(tp: Any) -> str:
+    return f"{tp.__module__}.{tp.__qualname__}"
+
+
+def import_structured_type(path: str) -> Any:
+    module_path, _, attr_path = path.rpartition(".")
+    module = importlib.import_module(module_path)
+    current = module
+    for part in attr_path.split("."):
+        current = getattr(current, part)
+    return current
+
+
+def coerce_structured_value(value: Any, info: Dict[str, str] | None) -> Any:
+    """Rebuild a structured instance from a dict when spec says so."""
+    if info is None:
+        return value
+    if is_structured_instance(value):
+        return value
+    if not isinstance(value, dict):
+        return value
+    cls = import_structured_type(info["path"])
+    kind = info.get("kind")
+    if kind == "pydantic":
+        if contains_tagged_value(value):
+            if hasattr(cls, "model_construct"):
+                return cls.model_construct(**value)
+            if hasattr(cls, "construct"):
+                return cls.construct(**value)
+            return cls(**value)
+        if hasattr(cls, "model_validate"):
+            return cls.model_validate(value)
+        if hasattr(cls, "parse_obj"):
+            return cls.parse_obj(value)
+        return cls(**value)
+    if kind == "dataclass":
+        return cls(**value)
+    return value
+
+
+def coerce_inputs_from_spec(values: Any, spec: Any) -> Any:
+    """Coerce dict inputs into structured instances based on spec metadata."""
+    if not isinstance(values, dict):
+        return values
+    try:
+        from node_graph.socket_spec import SocketSpec
+    except Exception:
+        return values
+    spec_obj = spec if isinstance(spec, SocketSpec) else SocketSpec.from_dict(spec)
+    out = dict(values)
+    for name, child in (spec_obj.fields or {}).items():
+        if name not in out:
+            continue
+        info = child.meta.extras.get("structured_type")
+        if info:
+            out[name] = coerce_structured_value(out[name], info)
+            continue
+        if child.is_namespace() and isinstance(out[name], dict):
+            out[name] = coerce_inputs_from_spec(out[name], child)
+    return out
+
+
+def contains_tagged_value(value: Any) -> bool:
+    """Return True if any TaggedValue appears in the structure."""
+    from node_graph.socket import TaggedValue
+
+    if isinstance(value, TaggedValue):
+        return True
+    if isinstance(value, BaseModel):
+        return any(
+            contains_tagged_value(getattr(value, name)) for name in value.model_fields
+        )
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in value.__dataclass_fields__.values():
+            if contains_tagged_value(getattr(value, field.name)):
+                return True
+        return False
+    if isinstance(value, dict):
+        return any(contains_tagged_value(v) for v in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return any(contains_tagged_value(v) for v in value)
+    return False

--- a/src/node_graph/utils/struct_utils.py
+++ b/src/node_graph/utils/struct_utils.py
@@ -64,13 +64,9 @@ def coerce_structured_value(value: Any, info: Dict[str, str] | None) -> Any:
         if contains_tagged_value(value):
             if hasattr(cls, "model_construct"):
                 return cls.model_construct(**value)
-            if hasattr(cls, "construct"):
-                return cls.construct(**value)
             return cls(**value)
         if hasattr(cls, "model_validate"):
             return cls.model_validate(value)
-        if hasattr(cls, "parse_obj"):
-            return cls.parse_obj(value)
         return cls(**value)
     if kind == "dataclass":
         return cls(**value)

--- a/tests/test_engine_local.py
+++ b/tests/test_engine_local.py
@@ -6,6 +6,8 @@ from node_graph.socket_spec import namespace as ns
 from node_graph.engine.local import LocalEngine
 from node_graph.engine.provenance import ProvenanceRecorder
 from typing import Annotated, Any
+from dataclasses import dataclass
+from pydantic import BaseModel
 
 
 @task()
@@ -154,3 +156,59 @@ def test_local_engine_records_call_edges():
     )
     edges = {(edge["src"], edge["dst"], edge["label"]) for edge in prov["edges"]}
     assert (graph_proc, nested_proc, "call") in edges
+
+
+class PydanticInputs(BaseModel):
+    x: int
+    y: int
+
+
+class PydanticOutputs(BaseModel):
+    sum: int
+    product: int
+
+
+@task()
+def add_multiply_pydantic(data: PydanticInputs) -> PydanticOutputs:
+    return PydanticOutputs(sum=data.x + data.y, product=data.x * data.y)
+
+
+@dataclass
+class DataclassInputs:
+    x: int
+    y: int
+
+
+@dataclass
+class DataclassOutputs:
+    sum: int
+    product: int
+
+
+@task()
+def add_multiply_dataclass(data: DataclassInputs) -> DataclassOutputs:
+    return DataclassOutputs(sum=data.x + data.y, product=data.x * data.y)
+
+
+def test_local_engine_accepts_pydantic_models():
+    ng = Graph(name="local-pydantic", outputs=ns(sum=int, product=int))
+    node = ng.add_task(add_multiply_pydantic, "calc", data=PydanticInputs(x=2, y=5))
+    ng.add_link(node.outputs.sum, ng.outputs.sum)
+    ng.add_link(node.outputs.product, ng.outputs.product)
+
+    results = LocalEngine().run(ng)
+
+    assert results["sum"] == 7
+    assert results["product"] == 10
+
+
+def test_local_engine_accepts_dataclass_models():
+    ng = Graph(name="local-dataclass", outputs=ns(sum=int, product=int))
+    node = ng.add_task(add_multiply_dataclass, "calc", data=DataclassInputs(x=3, y=4))
+    ng.add_link(node.outputs.sum, ng.outputs.sum)
+    ng.add_link(node.outputs.product, ng.outputs.product)
+
+    results = LocalEngine().run(ng)
+
+    assert results["sum"] == 7
+    assert results["product"] == 12

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -2,6 +2,7 @@ from node_graph import Graph, task
 from node_graph.socket_spec import namespace, dynamic
 from typing import Any
 import pytest
+from pydantic import BaseModel
 
 
 @task()
@@ -163,3 +164,46 @@ def test_graph_inputs_value():
     graph = test_graph.build(x=2, y=3)
     assert graph.inputs.x.value == 2
     assert graph.inputs.y.value == 3
+
+
+class SubInputs(BaseModel):
+    x: int
+    y: int
+
+
+class SubOutputs(BaseModel):
+    sum: int
+    product: int
+
+
+class MyInputs(BaseModel):
+    data1: SubInputs
+    data2: SubInputs
+
+
+@task()
+def add_multiply_pydantic(data: SubInputs) -> SubOutputs:
+    return SubOutputs(sum=data.x + data.y, product=data.x * data.y)
+
+
+def test_graph_inputs_pydantic_link_to_task_inputs():
+    @task.graph()
+    def add_graph(data: MyInputs):
+        add_multiply_pydantic(data=data.data1)
+        add_multiply_pydantic(data=data.data2)
+
+    data = MyInputs(data1=SubInputs(x=6, y=7), data2=SubInputs(x=1, y=2))
+    graph = add_graph.build(data=data)
+
+    def has_link(from_socket: str, to_socket: str) -> bool:
+        return any(
+            lk.from_task.name == "graph_inputs"
+            and lk.from_socket._scoped_name == from_socket
+            and lk.to_socket._scoped_name == to_socket
+            for lk in graph.links
+        )
+
+    assert has_link("data.data1.x", "data.x")
+    assert has_link("data.data1.y", "data.y")
+    assert has_link("data.data2.x", "data.x")
+    assert has_link("data.data2.y", "data.y")

--- a/tests/test_socket_spec.py
+++ b/tests/test_socket_spec.py
@@ -603,6 +603,8 @@ def test_leaf_pydantic_model():
 
     spec = ss.from_model(MySpec)
     assert not spec.is_namespace()
+    assert spec.identifier.endswith("annotated")
+    assert spec.meta.extras.get("py_type", "").endswith("MySpec")
 
     # Per-use leaf wrapper (even if model had no flag)
     class Other(BaseModel):
@@ -611,6 +613,8 @@ def test_leaf_pydantic_model():
 
     spec = ss.from_model(ss.Leaf[Other])
     assert not spec.is_namespace()
+    assert spec.identifier.endswith("annotated")
+    assert spec.meta.extras.get("py_type", "").endswith("Other")
 
 
 def test_dataclass_model_namespace_and_roundtrip():
@@ -683,6 +687,8 @@ def test_leaf_dataclass_model():
 
     spec = ss.from_model(MyLeafDC)
     assert not spec.is_namespace()
+    assert spec.identifier.endswith("annotated")
+    assert spec.meta.extras.get("py_type", "").endswith("MyLeafDC")
 
     @dataclass
     class OtherDC:
@@ -691,3 +697,5 @@ def test_leaf_dataclass_model():
 
     spec = ss.from_model(ss.Leaf[OtherDC])
     assert not spec.is_namespace()
+    assert spec.identifier.endswith("annotated")
+    assert spec.meta.extras.get("py_type", "").endswith("OtherDC")

--- a/tests/test_struct_utils.py
+++ b/tests/test_struct_utils.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from node_graph.socket import TaggedValue
+from node_graph.utils.struct_utils import contains_tagged_value
+
+
+def test_contains_tagged_value_dataclass():
+    @dataclass
+    class Payload:
+        x: int
+        y: object
+
+    tagged = Payload(x=1, y=TaggedValue(2))
+    plain = Payload(x=1, y=2)
+
+    assert contains_tagged_value(tagged) is True
+    assert contains_tagged_value(plain) is False


### PR DESCRIPTION
Previously, Pydantic Models or dataclasses are annotation-only. But this is counterintuitive!

In this PR allows users to use pydantic model as inputs, and outputs direclty. No need to provide plain dict.