### PR TITLE
Fix namespace-to-namespace linking

### DIFF
--- a/docs/gallery/autogen/annotate_inputs_outputs.py
+++ b/docs/gallery/autogen/annotate_inputs_outputs.py
@@ -104,7 +104,7 @@ def AddMultiplyInputs(x: int, y: int):
 
 
 wg = AddMultiplyInputs.build(x=1, y=2)
-wg.to_html()
+wg
 
 # %%
 # Note how the ``x`` input is passed to ``data.x`` (and similarly for ``y``).
@@ -499,7 +499,7 @@ wg = AddMultiplyFinal.build(
         "add_multiply2": {"data": {"x": 3, "y": 4}},
     },
 )
-wg.to_html()
+wg
 
 # %%
 # In the example above:
@@ -611,7 +611,7 @@ wg = UseExclude.build(
         },
     },
 )
-wg.to_html()
+wg
 
 # %%
 # In the GUI representation, you can see that the graph has a top-level ``structure`` input,

--- a/docs/gallery/autogen/quick_start.py
+++ b/docs/gallery/autogen/quick_start.py
@@ -48,7 +48,7 @@ def AddMultiply(x, y, z):
 
 
 ng = AddMultiply.build(x=1, y=2, z=3)
-ng.to_html()
+ng
 
 
 # %%
@@ -86,7 +86,7 @@ ng = Graph("first_workflow")
 ng.add_task(add, name="add", x=2, y=3)
 ng.add_task(multiply, name="multiply", y=4)
 ng.add_link(ng.tasks.add.outputs.result, ng.tasks.multiply.inputs.x)
-ng.to_html()
+ng
 
 # %%
 # What's Next

--- a/docs/gallery/autogen/zone.py
+++ b/docs/gallery/autogen/zone.py
@@ -59,7 +59,7 @@ def while_with_if(index=0, limit=10, total=0, increment=1):
 
 
 g = while_with_if.build(index=0, limit=10, total=0, increment=1)
-g.to_html()
+g
 
 # %%
 # If and While are available for both context-manager graphs and ``@task.graph``

--- a/docs/gallery/concept/autogen/graph_node_concept.py
+++ b/docs/gallery/concept/autogen/graph_node_concept.py
@@ -41,7 +41,7 @@ def add_multiply(x, y, z):
 #
 
 ng = add_multiply.build(1, 2, 3)
-ng.to_html()
+ng
 
 
 # %%
@@ -54,4 +54,4 @@ from node_graph import Graph
 
 g1 = Graph(name="group_usage")
 grp = g1.add_task(add_multiply, name="my_group")
-g1.to_html()
+g1

--- a/docs/gallery/concept/autogen/link.py
+++ b/docs/gallery/concept/autogen/link.py
@@ -1,0 +1,118 @@
+"""
+Links
+=====
+
+Links connect task outputs to task inputs. They can be between leaf sockets or
+between namespaces, with a few rules to keep graphs predictable and type-safe.
+"""
+
+# %%
+# Link rules
+# ----------
+#
+# .. list-table:: Link rules
+#    :header-rows: 1
+#
+#    * - Link type
+#      - Allowed
+#      - Notes
+#    * - leaf -> leaf
+#      - Yes
+#      - type-checked
+#    * - namespace -> namespace (both non-dynamic)
+#      - Yes
+#      - recursively links leaf sockets; shapes must match
+#    * - namespace -> namespace (any dynamic)
+#      - Yes
+#      - recursively links leaf sockets; no shape check
+#    * - leaf -> dynamic namespace
+#      - Yes
+#      - fan-in allowed
+#    * - leaf -> non-dynamic namespace
+#      - No
+#      -
+#    * - namespace -> leaf
+#      - No
+#      -
+#
+# Built-in sockets (names starting with "_") are ignored for namespace shape
+# checks and are not linked recursively. The special ``_outputs`` socket is the
+# top-level output namespace of a task; it can be dynamic or non-dynamic, and
+# can be linked as a namespace shortcut.
+
+# %%
+# Basic leaf-to-leaf linking
+# --------------------------
+from node_graph import Graph, task
+
+
+@task()
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+ng = Graph(name="link_example")
+add1 = ng.add_task(add, "add1", x=1, y=2)
+add2 = ng.add_task(add, "add2", x=add1.outputs.result, y=3)
+ng.add_link(add1.outputs.result, add2.inputs.x)
+ng
+
+# %%
+# Namespace-to-namespace linking
+# ------------------------------
+# When linking namespaces, node-graph recursively links all leaf sockets.
+# For non-dynamic namespaces, structures must match (built-in sockets like
+# ``_wait`` are ignored).
+from node_graph.socket_spec import namespace
+
+
+@task()
+def make_pair(x: int, y: int) -> namespace(sum=int, product=int):
+    return {"sum": x + y, "product": x * y}
+
+
+@task()
+def consume(data: namespace(sum=int, product=int)) -> int:
+    return data["sum"] + data["product"]
+
+
+ng_ns = Graph(name="namespace_link")
+make = ng_ns.add_task(make_pair, "make", x=2, y=3)
+take = ng_ns.add_task(consume, "take")
+ng_ns.add_link(make.outputs, take.inputs.data)
+ng_ns
+
+# %%
+# Dynamic namespace accepts leaf links
+# -----------------------------------
+# If the target namespace is dynamic, leaf sockets can be linked directly.
+from node_graph.socket_spec import dynamic
+
+
+@task()
+def emit(x: int) -> int:
+    return x
+
+
+@task()
+def collect(datas: dynamic(int)) -> int:
+    return 0
+
+
+ng_dyn = Graph(name="dynamic_namespace_link")
+src1 = ng_dyn.add_task(emit, "emit1")
+src2 = ng_dyn.add_task(emit, "emit2")
+dst = ng_dyn.add_task(collect, "collect")
+ng_dyn.add_link(src1.outputs.result, dst.inputs.datas)
+ng_dyn.add_link(src2.outputs.result, dst.inputs.datas)
+ng_dyn
+
+# %%
+# Top-level outputs namespace shortcut
+# ------------------------------------
+# If you link a top-level outputs namespace to a leaf, node-graph uses the
+# built-in ``_outputs`` socket to represent the namespace as a whole.
+ng_out = Graph(name="top_level_outputs")
+producer = ng_out.add_task(make_pair, "producer", x=1, y=2)
+ng_out.add_link(producer.outputs._outputs, ng_out.outputs)  # shortcut form
+ng_out

--- a/docs/gallery/concept/autogen/node_concept.py
+++ b/docs/gallery/concept/autogen/node_concept.py
@@ -25,7 +25,7 @@ def myadd(x, y):
 ng2 = Graph(name="test_decorator")
 add1 = ng2.add_task(myadd, "add1", x=1, y=2)
 add2 = ng2.add_task(myadd, "add2", x=3, y=add1.outputs.result)
-ng2.to_html()
+ng2
 
 # %%
 # Define a custom task class

--- a/docs/gallery/concept/autogen/nodegraph_concept.py
+++ b/docs/gallery/concept/autogen/nodegraph_concept.py
@@ -34,7 +34,7 @@ add1 = g.add_task("node_graph.test_add", name="add1")
 
 g.add_link(float1.outputs.result, add1.inputs.x)
 
-g.to_html()
+g
 # %%
 # Save to dict
 # ------------

--- a/docs/source/concept/index.rst
+++ b/docs/source/concept/index.rst
@@ -12,4 +12,5 @@ Concepts
    autogen/nodegraph_concept
    autogen/socket_concept
    autogen/graph_node_concept
+   autogen/link
    execution

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,6 @@
 #
 import os
 import sys
-import shutil
-from pathlib import Path
 
 
 sys.path.insert(0, os.path.abspath("../.."))
@@ -68,6 +66,7 @@ sphinx_gallery_conf = {
     "filename_pattern": "/*",
     "examples_dirs": gallery_src_dirs,  # in sphinx-gallery doc referred as gallery source
     "gallery_dirs": sphinx_src_autogen_dirs,  # path to where to gallery puts generated files
+    "capture_repr": ("_repr_html_", "__repr__"),
 }
 
 exclude_patterns = []
@@ -123,53 +122,3 @@ html_theme_options = {
 
 # pygments_style = "colorful"
 # pygments_dark_style = "monokai"
-
-
-# Function to copy HTML files
-def copy_html_files(app, exception):
-    """
-    Copy all .html files from source to build directory, maintaining the directory structure.
-    """
-    copy_print_info = "Copying HTML files to build directory"
-    print()
-    print(copy_print_info)
-    print(len(copy_print_info) * "=")
-    if exception is not None:  # Only copy files if the build succeeded
-        print(
-            "Build failed, but we still try to copy the HTML files to the build directory"
-        )
-    try:
-        src_path = Path(app.builder.srcdir)
-        build_path = Path(app.builder.outdir)
-
-        copy_print_info = f"Copying html files from sphinx src directory {src_path}"
-        print()
-        print(copy_print_info)
-        print(len(copy_print_info) * "-")
-        for html_file in src_path.rglob("*.html"):
-            relative_path = html_file.relative_to(src_path)
-            destination_file = build_path / relative_path
-            destination_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(html_file, destination_file)
-            print(f"Copy {html_file} to {destination_file}")
-
-        gallery_src_path = Path(app.builder.srcdir / Path(gallery_src_relative_dir))
-
-        copy_print_info = (
-            f"Copying html files from gallery src directory {gallery_src_path} to build"
-        )
-        print()
-        print(copy_print_info)
-        print(len(copy_print_info) * "-")
-        for html_file in gallery_src_path.rglob("*.html"):
-            relative_path = html_file.relative_to(gallery_src_path)
-            destination_file = build_path / relative_path
-            destination_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(html_file, destination_file)
-            print(f"Copy {html_file} to {destination_file}")
-    except Exception as e:
-        print(f"Failed to copy HTML files: {e}")
-
-
-def setup(app):
-    app.connect("build-finished", copy_html_files)

--- a/src/node_graph/engine/local.py
+++ b/src/node_graph/engine/local.py
@@ -74,6 +74,7 @@ class LocalEngine(BaseEngine):
                 links=incoming.get("graph_outputs", []),
                 source_map=values,
             )
+            # graph_outputs = update_nested_dict_with_special_keys(graph_outputs)
             return self._finalize_graph_success(ng, graph_pid, graph_outputs)
         except Exception as e:
             self._record_graph_failure(graph_pid, e)

--- a/src/node_graph/graph.py
+++ b/src/node_graph/graph.py
@@ -7,7 +7,7 @@ from node_graph.socket_spec import SocketSpec, SocketSpecAPI
 from typing import Dict, Any, List, Optional, Union, Callable
 import yaml
 from node_graph.task import Task
-from node_graph.socket import TaskSocket
+from node_graph.socket import TaskSocket, TaskSocketNamespace
 from node_graph.link import TaskLink
 from node_graph.utils import yaml_to_dict
 from .config import BuiltinPolicy, BUILTIN_TASKS, MAX_LINK_LIMIT
@@ -330,21 +330,39 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
         self._version += 1
         return task
 
-    def add_link(self, source: TaskSocket | Task, target: TaskSocket) -> TaskLink:
+    def add_link(
+        self,
+        source: TaskSocket | Task,
+        target: TaskSocket | "TaskSocketNamespace",
+    ) -> TaskLink | None:
         """Add a link between two tasks."""
-        from node_graph.socket import TaskSocketNamespace
 
         if isinstance(source, Task):
             source = source.outputs["graph_outputs"]
         elif source._parent is None and isinstance(source, TaskSocketNamespace):
-            # if the source is the top-level outputs,
-            # we use the built-in "_outputs" socket to represent it
-            if "_outputs" in source:
-                source = source["_outputs"]
-            else:
-                raise ValueError(
-                    f"You try to link a top-level output socket {source._name} without a parent."
-                )
+            if not isinstance(target, TaskSocketNamespace):
+                # if the source is the top-level outputs,
+                # we use the built-in "_outputs" socket to represent it
+                if "_outputs" in source:
+                    source = source["_outputs"]
+                else:
+                    raise ValueError(
+                        f"You try to link a top-level output socket {source._name} without a parent."
+                    )
+
+        if isinstance(source, TaskSocketNamespace) or isinstance(
+            target, TaskSocketNamespace
+        ):
+            if isinstance(source, TaskSocketNamespace) and isinstance(
+                target, TaskSocketNamespace
+            ):
+                return self._add_namespace_link(source, target)
+            src = getattr(source, "_full_name_with_task", "<unknown>")
+            dst = getattr(target, "_full_name_with_task", "<unknown>")
+            raise TypeError(
+                "Linking a namespace socket directly to a leaf socket is not allowed. "
+                f"Got {src} -> {dst}."
+            )
         #
         key = f"{source._task.name}.{source._scoped_name} -> {target._task.name}.{target._scoped_name}"
         if key in self.links:
@@ -352,6 +370,40 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
         link = self.links._new(source, target)
         self._version += 1
         return link
+
+    def _add_namespace_link(
+        self,
+        source: "TaskSocketNamespace",
+        target: "TaskSocketNamespace",
+    ) -> TaskLink | None:
+        last_link: TaskLink | None = None
+        for name, target_child in target._sockets.items():
+            if name not in source._sockets:
+                src = source._full_name_with_task
+                dst = target._full_name_with_task
+                raise ValueError(
+                    f"Namespace link mismatch: '{name}' not found in source {src} "
+                    f"while linking to {dst}."
+                )
+            source_child = source._sockets[name]
+            if isinstance(source_child, TaskSocketNamespace) and isinstance(
+                target_child, TaskSocketNamespace
+            ):
+                child_link = self._add_namespace_link(source_child, target_child)
+                if child_link is not None:
+                    last_link = child_link
+                continue
+            if isinstance(source_child, TaskSocketNamespace) or isinstance(
+                target_child, TaskSocketNamespace
+            ):
+                src = source_child._full_name_with_task
+                dst = target_child._full_name_with_task
+                raise TypeError(
+                    "Namespace link mismatch: tried to link a namespace with a leaf "
+                    f"socket at {src} -> {dst}."
+                )
+            last_link = self.add_link(source_child, target_child)
+        return last_link
 
     def append_task(self, task: Task) -> None:
         """Appends a task to the task graph."""

--- a/src/node_graph/graph.py
+++ b/src/node_graph/graph.py
@@ -233,8 +233,6 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
 
     def expose_inputs(self, names: Optional[List[str]] = None) -> None:
         """Generate group inputs from tasks."""
-        from node_graph.socket_spec import remove_spec_field
-
         all_names = set(self.tasks._get_keys())
         names = set(names or all_names)
         missing = names - all_names
@@ -244,22 +242,13 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
             task = self.tasks[name]
             # update the _inputs spec
             if task.spec.inputs is not None:
-                # skip linked sockets
-                names = [
-                    link.to_socket._scoped_name
-                    for link in self.links
-                    if link.to_task == task
-                ]
-                spec = remove_spec_field(task.spec.inputs, names=names)
-                socket = self.add_input_spec(spec, name=task.name)
-                keys = task.inputs._get_all_keys()
-                exist_keys = socket._get_all_keys()
-                for key in keys:
-                    new_key = f"{task.name}.{key}"
-                    if new_key not in exist_keys:
-                        continue
-                    # add link from group inputs to task inputs
-                    self.add_link(self.inputs[new_key], task.inputs[key])
+                socket = self.add_input_spec(task.spec.inputs, name=task.name)
+                # add link from group inputs to task inputs
+                self.add_link(
+                    socket,
+                    task.inputs,
+                    allow_skip_linked=True,
+                )
 
     def expose_outputs(self, names: Optional[List[str]] = None) -> None:
         """Generate group outputs from tasks."""
@@ -272,14 +261,12 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
             task = self.tasks[name]
             if task.spec.outputs is not None:
                 socket = self.add_output_spec(task.spec.outputs, name=task.name)
-                keys = task.outputs._get_all_keys()
-                exist_keys = socket._get_all_keys()
-                for key in keys:
-                    new_key = f"{task.name}.{key}"
-                    if new_key not in exist_keys:
-                        continue
-                    # add link from task outputs to group outputs
-                    self.add_link(task.outputs[key], self.outputs[new_key])
+                # add link from task outputs to group outputs
+                self.add_link(
+                    task.outputs,
+                    socket,
+                    allow_skip_linked=True,
+                )
 
     def set_inputs(self, inputs: Dict[str, Any]):
         for name, input in inputs.items():
@@ -334,8 +321,16 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
         self,
         source: TaskSocket | Task,
         target: TaskSocket | "TaskSocketNamespace",
+        *,
+        allow_skip_linked: bool = False,
     ) -> TaskLink | None:
-        """Add a link between two tasks."""
+        """Add a link between two sockets or namespace sockets.
+
+        When linking namespaces, all leaf sockets are linked recursively and a
+        namespace-level link is also created for bookkeeping. Set
+        allow_skip_linked=True to skip targets that are already linked.
+        """
+        from node_graph.socket import TaskSocketNamespace
 
         if isinstance(source, Task):
             source = source.outputs["graph_outputs"]
@@ -356,7 +351,21 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
             if isinstance(source, TaskSocketNamespace) and isinstance(
                 target, TaskSocketNamespace
             ):
-                return self._add_namespace_link(source, target)
+                if not (source._metadata.dynamic or target._metadata.dynamic):
+                    source_keys = source._relative_keys()
+                    target_keys = target._relative_keys()
+                    if source_keys != target_keys:
+                        src = source._full_name_with_task
+                        dst = target._full_name_with_task
+                        raise ValueError(
+                            "Namespace structures do not match for linking: "
+                            f"{src} vs {dst}. "
+                            f"Missing in source: {sorted(target_keys - source_keys)}. "
+                            f"Missing in target: {sorted(source_keys - target_keys)}."
+                        )
+                return self._add_namespace_link(
+                    source, target, allow_skip_linked=allow_skip_linked
+                )
             src = getattr(source, "_full_name_with_task", "<unknown>")
             dst = getattr(target, "_full_name_with_task", "<unknown>")
             raise TypeError(
@@ -371,13 +380,39 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
         self._version += 1
         return link
 
+    def _has_incoming_links(self, item: TaskSocket | "TaskSocketNamespace") -> bool:
+        """Return True if the target socket already has incoming links."""
+        return any(link.to_socket is item for link in item._links)
+
     def _add_namespace_link(
         self,
         source: "TaskSocketNamespace",
         target: "TaskSocketNamespace",
+        *,
+        allow_skip_linked: bool = False,
     ) -> TaskLink | None:
+        """Link two namespaces, optionally skipping already-linked targets."""
+        from node_graph.socket import TaskSocketNamespace
+
         last_link: TaskLink | None = None
+        link_source: TaskSocket | TaskSocketNamespace = source
+        if source._parent is None and "_outputs" in source:
+            link_source = source["_outputs"]
+
+        if not (allow_skip_linked and self._has_incoming_links(target)):
+            key = (
+                f"{link_source._task.name}.{link_source._scoped_name} -> "
+                f"{target._task.name}.{target._scoped_name}"
+            )
+            if key in self.links:
+                last_link = self.links[key]
+            else:
+                last_link = self.links._new(link_source, target)
+                self._version += 1
+
         for name, target_child in target._sockets.items():
+            if name.startswith("_"):
+                continue
             if name not in source._sockets:
                 src = source._full_name_with_task
                 dst = target._full_name_with_task
@@ -386,10 +421,23 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
                     f"while linking to {dst}."
                 )
             source_child = source._sockets[name]
+            if self._has_incoming_links(target_child):
+                if allow_skip_linked:
+                    continue
+                src = source_child._full_name_with_task
+                dst = target_child._full_name_with_task
+                raise ValueError(
+                    "Namespace link conflict: target socket already linked at "
+                    f"{src} -> {dst}."
+                )
             if isinstance(source_child, TaskSocketNamespace) and isinstance(
                 target_child, TaskSocketNamespace
             ):
-                child_link = self._add_namespace_link(source_child, target_child)
+                child_link = self._add_namespace_link(
+                    source_child,
+                    target_child,
+                    allow_skip_linked=allow_skip_linked,
+                )
                 if child_link is not None:
                     last_link = child_link
                 continue

--- a/src/node_graph/graph.py
+++ b/src/node_graph/graph.py
@@ -332,18 +332,7 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
         """
         from node_graph.socket import TaskSocketNamespace
 
-        if isinstance(source, Task):
-            source = source.outputs["graph_outputs"]
-        elif source._parent is None and isinstance(source, TaskSocketNamespace):
-            if not isinstance(target, TaskSocketNamespace):
-                # if the source is the top-level outputs,
-                # we use the built-in "_outputs" socket to represent it
-                if "_outputs" in source:
-                    source = source["_outputs"]
-                else:
-                    raise ValueError(
-                        f"You try to link a top-level output socket {source._name} without a parent."
-                    )
+        source, target = self._normalize_link_endpoints(source, target)
 
         if isinstance(source, TaskSocketNamespace) or isinstance(
             target, TaskSocketNamespace
@@ -351,21 +340,42 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
             if isinstance(source, TaskSocketNamespace) and isinstance(
                 target, TaskSocketNamespace
             ):
-                if not (source._metadata.dynamic or target._metadata.dynamic):
+                if not self._namespace_structures_match(source, target):
                     source_keys = source._relative_keys()
                     target_keys = target._relative_keys()
-                    if source_keys != target_keys:
-                        src = source._full_name_with_task
-                        dst = target._full_name_with_task
-                        raise ValueError(
-                            "Namespace structures do not match for linking: "
-                            f"{src} vs {dst}. "
-                            f"Missing in source: {sorted(target_keys - source_keys)}. "
-                            f"Missing in target: {sorted(source_keys - target_keys)}."
-                        )
+                    src = source._full_name_with_task
+                    dst = target._full_name_with_task
+                    raise ValueError(
+                        "Namespace structures do not match for linking: "
+                        f"{src} vs {dst}. "
+                        f"Missing in source: {sorted(target_keys - source_keys)}. "
+                        f"Missing in target: {sorted(source_keys - target_keys)}."
+                    )
                 return self._add_namespace_link(
                     source, target, allow_skip_linked=allow_skip_linked
                 )
+            if (
+                isinstance(target, TaskSocketNamespace)
+                and target._metadata.dynamic
+                and not isinstance(source, TaskSocketNamespace)
+            ):
+                return self._add_leaf_link(source, target)
+            if (
+                isinstance(target, TaskSocketNamespace)
+                and not isinstance(source, TaskSocketNamespace)
+                and getattr(source, "_scoped_name", None) == "_outputs"
+            ):
+                return self._add_leaf_link(source, target)
+            if isinstance(source, TaskSocketNamespace):
+                normalized = self._normalize_namespace_source(source)
+                if normalized is None:
+                    src = getattr(source, "_full_name_with_task", "<unknown>")
+                    dst = getattr(target, "_full_name_with_task", "<unknown>")
+                    raise TypeError(
+                        "Linking a namespace socket directly to a leaf socket is not allowed. "
+                        f"Got {src} -> {dst}."
+                    )
+                return self._add_leaf_link(normalized, target)
             src = getattr(source, "_full_name_with_task", "<unknown>")
             dst = getattr(target, "_full_name_with_task", "<unknown>")
             raise TypeError(
@@ -373,12 +383,64 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
                 f"Got {src} -> {dst}."
             )
         #
-        key = f"{source._task.name}.{source._scoped_name} -> {target._task.name}.{target._scoped_name}"
+        return self._add_leaf_link(source, target)
+
+    def _normalize_link_endpoints(
+        self,
+        source: TaskSocket | Task,
+        target: TaskSocket | "TaskSocketNamespace",
+    ) -> tuple[TaskSocket | "TaskSocketNamespace", TaskSocket | "TaskSocketNamespace"]:
+        from node_graph.socket import TaskSocketNamespace
+
+        if isinstance(source, Task):
+            source = source.outputs["graph_outputs"]
+        elif source._parent is None and isinstance(source, TaskSocketNamespace):
+            if not isinstance(target, TaskSocketNamespace):
+                # if the source is the top-level outputs,
+                # we use the built-in "_outputs" socket to represent it
+                normalized = self._normalize_namespace_source(source)
+                if normalized is None:
+                    raise ValueError(
+                        f"You try to link a top-level output socket {source._name} without a parent."
+                    )
+                source = normalized
+        return source, target
+
+    def _normalize_namespace_source(
+        self, source: "TaskSocketNamespace"
+    ) -> TaskSocket | "TaskSocketNamespace":
+        if "_outputs" in source:
+            return source["_outputs"]
+        return None
+
+    def _link_key(
+        self,
+        source: TaskSocket | "TaskSocketNamespace",
+        target: TaskSocket | "TaskSocketNamespace",
+    ) -> str:
+        return (
+            f"{source._task.name}.{source._scoped_name} -> "
+            f"{target._task.name}.{target._scoped_name}"
+        )
+
+    def _add_leaf_link(
+        self,
+        source: TaskSocket | "TaskSocketNamespace",
+        target: TaskSocket | "TaskSocketNamespace",
+    ) -> TaskLink:
+        key = self._link_key(source, target)
         if key in self.links:
             return self.links[key]
         link = self.links._new(source, target)
         self._version += 1
         return link
+
+    def _namespace_structures_match(
+        self, source: "TaskSocketNamespace", target: "TaskSocketNamespace"
+    ) -> bool:
+        if source._metadata.dynamic or target._metadata.dynamic:
+            return True
+        return source._relative_keys() == target._relative_keys()
 
     def _has_incoming_links(self, item: TaskSocket | "TaskSocketNamespace") -> bool:
         """Return True if the target socket already has incoming links."""
@@ -400,19 +462,13 @@ class Graph(IOOwnerMixin, WidgetRenderableMixin):
             link_source = source["_outputs"]
 
         if not (allow_skip_linked and self._has_incoming_links(target)):
-            key = (
-                f"{link_source._task.name}.{link_source._scoped_name} -> "
-                f"{target._task.name}.{target._scoped_name}"
-            )
+            key = self._link_key(link_source, target)
             if key in self.links:
                 last_link = self.links[key]
             else:
-                last_link = self.links._new(link_source, target)
-                self._version += 1
+                last_link = self._add_leaf_link(link_source, target)
 
-        for name, target_child in target._sockets.items():
-            if name.startswith("_"):
-                continue
+        for name, target_child in target._iter_children(include_builtins=False):
             if name not in source._sockets:
                 src = source._full_name_with_task
                 dst = target._full_name_with_task

--- a/src/node_graph/mixins.py
+++ b/src/node_graph/mixins.py
@@ -97,6 +97,25 @@ class WidgetRenderableMixin:
             return self.widget._repr_mimebundle_(*args, **kwargs)
         return self.widget._ipython_display_(*args, **kwargs)
 
+    def _repr_html_(self):
+        """Return a standalone iframe embedding the widget HTML for static docs."""
+        try:
+            from node_graph_widget.html_template import html_template
+        except Exception:
+            return None
+        import html
+        import json
+
+        self.widget.value = self.to_widget_value()
+        html_content = html_template.replace(
+            "__NODEGRAPH_DATA__", json.dumps(self.widget.value)
+        )
+        return (
+            '<iframe srcdoc="'
+            + html.escape(html_content, quote=True)
+            + '" width="100%" height="600px" frameborder="0" allowfullscreen></iframe>'
+        )
+
     def to_html(self, output: str = None, **kwargs):
         """Write a standalone html file to visualize the task."""
         self.widget.value = self.to_widget_value()

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -1142,6 +1142,148 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
     def _value(self, value: Dict[str, Any]) -> None:
         self._set_socket_value(value)
 
+    def _link_namespace_socket(self, value: BaseSocket) -> None:
+        """Link a socket directly to this namespace."""
+        self._clear_updatable_meta()
+        self._task.graph.add_link(value, self)
+
+    def _append_dynamic_child(self, key: str, val: Any) -> None:
+        from node_graph.socket_spec import SocketSpec
+
+        extras = self._metadata.extras or {}
+        item_snapshot = extras.get("item") if isinstance(extras, dict) else None
+        if item_snapshot is None:
+            if isinstance(val, (dict, TaskSocketNamespace)):
+                item_snapshot = {
+                    "identifier": self._type_mapping["namespace"],
+                    "dynamic": True,
+                }
+            else:
+                item_snapshot = {"identifier": self._type_mapping["default"]}
+        item_spec = (
+            SocketSpec.from_dict(item_snapshot)
+            if isinstance(item_snapshot, dict)
+            else None
+        )
+        self._append_from_spec(
+            self,
+            key,
+            item_spec,
+            task=self._task,
+            graph=self._graph,
+            role="input",
+        )
+
+    def _get_or_create_child(self, key: str, val: Any) -> object:
+        if key in self._sockets:
+            return self._sockets[key]
+        if key.startswith("_"):
+            _raise_namespace_assignment_error(
+                target_ns=self,
+                incoming_desc=f"key '{key}'",
+                reason=f"Field '{key}' is a reserved builtin socket.",
+                fixes=[
+                    "Remove the builtin key from the assignment; or",
+                    "link to an explicit leaf socket instead of the namespace.",
+                ],
+            )
+        if not self._metadata.dynamic:
+            _raise_namespace_assignment_error(
+                target_ns=self,
+                incoming_desc=f"key '{key}'",
+                reason=f"Field '{key}' is not defined and this namespace is not dynamic.",
+                fixes=[
+                    "Add the field to the namespace spec; or",
+                    "make the namespace dynamic if it should grow automatically.",
+                ],
+            )
+        self._append_dynamic_child(key, val)
+        return self._sockets[key]
+
+    def _assign_key_value(self, key: str, val: Any, *, value_source: str) -> None:
+        if "." in key:
+            head, tail = key.split(".", 1)
+            if head not in self._sockets:
+                if head.startswith("_"):
+                    _raise_namespace_assignment_error(
+                        target_ns=self,
+                        incoming_desc=f"key '{head}'",
+                        reason=f"Field '{head}' is a reserved builtin socket.",
+                        fixes=[
+                            "Remove the builtin key from the assignment; or",
+                            "link to an explicit leaf socket instead of the namespace.",
+                        ],
+                    )
+                if not self._metadata.dynamic:
+                    _raise_namespace_assignment_error(
+                        target_ns=self,
+                        incoming_desc=f"key '{head}'",
+                        reason=f"Field '{head}' is not defined and this namespace is not dynamic.",
+                        fixes=[
+                            "Define the field in the socket spec (preferred); or",
+                            "mark this namespace dynamic if it must accept arbitrary keys;",
+                            "or correct the key path being assigned.",
+                        ],
+                    )
+                self._new(
+                    self._SocketPool["namespace"],
+                    head,
+                    metadata={
+                        "dynamic": True,
+                        "child_default_link_limit": self._metadata.child_default_link_limit,
+                    },
+                )
+            child = self._sockets[head]
+            if not isinstance(child, TaskSocketNamespace):
+                _raise_namespace_assignment_error(
+                    target_ns=self,
+                    incoming_desc=f"nested key '{key}' under leaf '{head}'",
+                    reason=f"'{head}' is a leaf socket, but you attempted to assign nested data below it.",
+                    fixes=[
+                        "Use a namespace socket for hierarchical data; update your SocketSpec accordingly; or",
+                        "flatten your assignment to target a leaf socket directly.",
+                    ],
+                )
+            child._set_socket_value({tail: val}, value_source=value_source)
+            return
+
+        target = self._get_or_create_child(key, val)
+        if isinstance(target, TaskSocketNamespace):
+            if is_structured_instance(val):
+                val = structured_to_dict(val)
+            if isinstance(val, TaskSocketNamespace):
+                target._set_socket_value(val, value_source=value_source)
+                return
+            if isinstance(val, BaseSocket):
+                if target._metadata.dynamic:
+                    target._set_socket_value(val, value_source=value_source)
+                    return
+                if getattr(val, "_scoped_name", None) == "_outputs":
+                    target._set_socket_value(val, value_source=value_source)
+                    return
+                _raise_namespace_assignment_error(
+                    target_ns=target,
+                    incoming_desc=type(val).__name__,
+                    reason="A non-dynamic namespace cannot accept a direct socket link.",
+                    fixes=[
+                        "Link a specific leaf socket instead of the namespace; or",
+                        "make the namespace dynamic if it should accept multiple links.",
+                    ],
+                )
+            if isinstance(val, (dict, TaskSocketNamespace)):
+                target._set_socket_value(val, value_source=value_source)
+                return
+            _raise_namespace_assignment_error(
+                target_ns=target,
+                incoming_desc=type(val).__name__,
+                reason="A namespace expects a mapping of fields, but a non-dict value was provided.",
+                fixes=[
+                    "Provide a dict like {'x': 1, 'y': 2} that matches the namespace shape.",
+                ],
+            )
+        else:
+            target._set_socket_value(val, value_source=value_source)
+
     def _set_socket_value(
         self, value: Dict[str, Any] | TaskSocket, *, value_source: str = "link"
     ) -> None:
@@ -1156,8 +1298,6 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
         - Missing immediate children can be created only if *this* namespace is dynamic.
         - Intermediate dotted segments are created as namespaces (dynamic=True) when needed.
         """
-        from node_graph.socket_spec import SocketSpec
-
         if value is None:
             return
         if is_structured_instance(value):
@@ -1165,8 +1305,7 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
 
         # Link another socket directly to this namespace
         if isinstance(value, BaseSocket):
-            self._clear_updatable_meta()
-            self._task.graph.add_link(value, self)
+            self._link_namespace_socket(value)
             return
 
         if isinstance(value, TaggedValue):
@@ -1202,108 +1341,7 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
             )
 
         for key, val in value.items():
-            # If the key is dotted, descend or create per segment
-            if "." in key:
-                head, tail = key.split(".", 1)
-
-                # Ensure the immediate child exists (create if allowed)
-                if head not in self._sockets:
-                    if not self._metadata.dynamic:
-                        _raise_namespace_assignment_error(
-                            target_ns=self,
-                            incoming_desc=f"key '{head}'",
-                            reason=f"Field '{head}' is not defined and this namespace is not dynamic.",
-                            fixes=[
-                                "Define the field in the socket spec (preferred); or",
-                                "mark this namespace dynamic if it must accept arbitrary keys;",
-                                "or correct the key path being assigned.",
-                            ],
-                        )
-                    # We are going to descend (tail exists), so create a namespace
-                    self._new(
-                        self._SocketPool["namespace"],
-                        head,
-                        metadata={
-                            "dynamic": True,
-                            "child_default_link_limit": self._metadata.child_default_link_limit,
-                        },
-                    )
-
-                child = self._sockets[head]
-                if not isinstance(child, TaskSocketNamespace):
-                    _raise_namespace_assignment_error(
-                        target_ns=self,
-                        incoming_desc=f"nested key '{key}' under leaf '{head}'",
-                        reason=f"'{head}' is a leaf socket, but you attempted to assign nested data below it.",
-                        fixes=[
-                            "Use a namespace socket for hierarchical data; update your SocketSpec accordingly; or",
-                            "flatten your assignment to target a leaf socket directly.",
-                        ],
-                    )
-
-                # Recurse into the child namespace with the remaining tail
-                child._set_socket_value({tail: val}, value_source=value_source)
-                continue  # next key
-
-            # Non-dotted key path (single-segment)
-            if key not in self._sockets:
-                if not self._metadata.dynamic:
-                    _raise_namespace_assignment_error(
-                        target_ns=self,
-                        incoming_desc=f"key '{key}'",
-                        reason=f"Field '{key}' is not defined and this namespace is not dynamic.",
-                        fixes=[
-                            "Add the field to the namespace spec; or",
-                            "make the namespace dynamic if it should grow automatically.",
-                        ],
-                    )
-
-                # Create a leaf or namespace based on the dynamic item type
-                extras = self._metadata.extras or {}
-                item_snapshot = extras.get("item") if isinstance(extras, dict) else None
-                if item_snapshot is None:
-                    if isinstance(val, (dict, TaskSocketNamespace)):
-                        item_snapshot = {
-                            "identifier": self._type_mapping["namespace"],
-                            "dynamic": True,
-                        }
-                    else:
-                        item_snapshot = {"identifier": self._type_mapping["default"]}
-                item_spec = (
-                    SocketSpec.from_dict(item_snapshot)
-                    if isinstance(item_snapshot, dict)
-                    else None
-                )
-                self._append_from_spec(
-                    self,
-                    key,
-                    item_spec,
-                    task=self._task,
-                    graph=self._graph,
-                    role="input",
-                )
-
-            # Now we’re guaranteed the key exists; delegate appropriately
-            target = self._sockets[key]
-            if isinstance(target, TaskSocketNamespace):
-                if is_structured_instance(val):
-                    val = structured_to_dict(val)
-                # If incoming val is a dict, recurse. If it’s a socket, link to the namespace.
-                if isinstance(val, (dict, TaskSocketNamespace)):
-                    target._set_socket_value(val, value_source=value_source)
-                else:
-                    # Treat setting a leaf value into a namespace as error for clarity
-                    _raise_namespace_assignment_error(
-                        target_ns=target,
-                        incoming_desc=type(val).__name__,
-                        reason="A namespace expects a mapping of fields, but a non-dict value was provided.",
-                        fixes=[
-                            "Provide a dict like {'x': 1, 'y': 2} that matches the namespace shape.",
-                        ],
-                    )
-            else:
-                # Leaf socket: forward to its own setter (which handles linking or value assignment)
-                target._set_socket_value(val, value_source=value_source)
+            self._assign_key_value(key, val, value_source=value_source)
 
     def _export_updatable_meta_map(self) -> Dict[str, Dict[str, Any]]:
         """Export whitelisted metadata extras keyed by scoped socket path."""
@@ -1633,14 +1671,25 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
         nested = list(self._sockets.keys())
         return f"{self.__class__.__name__}(name='{self._name}', sockets={nested})"
 
+    def _iter_children(
+        self, *, include_builtins: bool = False
+    ) -> list[tuple[str, object]]:
+        """Iterate namespace children, optionally including builtin sockets."""
+        items = []
+        for name, child in self._sockets.items():
+            if not include_builtins and name.startswith("_"):
+                continue
+            items.append((name, child))
+        return items
+
     def _relative_keys(self, *, include_builtins: bool = False) -> set[str]:
         """Return leaf socket paths relative to this namespace."""
         keys: set[str] = set()
 
         def _walk(namespace: "TaskSocketNamespace", prefix: str = "") -> None:
-            for name, child in namespace._sockets.items():
-                if not include_builtins and name.startswith("_"):
-                    continue
+            for name, child in namespace._iter_children(
+                include_builtins=include_builtins
+            ):
                 path = f"{prefix}{name}" if prefix else name
                 if isinstance(child, TaskSocketNamespace):
                     _walk(child, f"{path}.")

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -1289,10 +1289,8 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
                 if is_structured_instance(val):
                     val = structured_to_dict(val)
                 # If incoming val is a dict, recurse. If it’s a socket, link to the namespace.
-                if isinstance(val, dict):
+                if isinstance(val, (dict, TaskSocketNamespace)):
                     target._set_socket_value(val, value_source=value_source)
-                elif isinstance(val, BaseSocket):
-                    self._task.graph.add_link(val, target)
                 else:
                     # Treat setting a leaf value into a namespace as error for clarity
                     _raise_namespace_assignment_error(
@@ -1634,3 +1632,20 @@ class TaskSocketNamespace(BaseSocket, OperatorSocketMixin):
     def __repr__(self) -> str:
         nested = list(self._sockets.keys())
         return f"{self.__class__.__name__}(name='{self._name}', sockets={nested})"
+
+    def _relative_keys(self, *, include_builtins: bool = False) -> set[str]:
+        """Return leaf socket paths relative to this namespace."""
+        keys: set[str] = set()
+
+        def _walk(namespace: "TaskSocketNamespace", prefix: str = "") -> None:
+            for name, child in namespace._sockets.items():
+                if not include_builtins and name.startswith("_"):
+                    continue
+                path = f"{prefix}{name}" if prefix else name
+                if isinstance(child, TaskSocketNamespace):
+                    _walk(child, f"{path}.")
+                else:
+                    keys.add(path)
+
+        _walk(self)
+        return keys

--- a/tests/test_engine_local.py
+++ b/tests/test_engine_local.py
@@ -101,6 +101,7 @@ def test_local_engine_handles_nested_and_dynamic_outputs():
     ng = composed.build(data={"x": 2, "y": 3})
     engine = LocalEngine()
     values = engine.run(ng)
+    print("values: ", values)
 
     assert values["add_multiply"]["sum"] == 11
     assert values["square"]["square_4"] == 16

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -176,13 +176,22 @@ def test_expose_inputs_names_invalid(test_ng):
 
 
 def test_expose_inputs_skip_linked(test_ng):
-    """Test generation of inputs from tasks, skip linked sockets"""
+    """Test generation of inputs from tasks, skip linking for linked sockets"""
     ng = test_ng
     ng.add_link(ng.tasks.add1.outputs.output1.x, ng.tasks.add2.inputs.input1.x)
     ng.expose_inputs()
     assert "add2" in ng.inputs
-    assert "input1.x" not in ng.inputs.add2
+    assert "input1.x" in ng.inputs.add2
     assert "input1.y" in ng.inputs.add2
+    assert all(
+        link.from_socket is not ng.inputs.add2.input1.x
+        for link in ng.tasks.add2.inputs.input1.x._links
+    )
+    assert any(
+        link.from_socket is ng.inputs.add2.input1.y
+        and link.to_socket is ng.tasks.add2.inputs.input1.y
+        for link in ng.tasks.add2.inputs.input1.y._links
+    )
     # outputs will still have all sockets
     ng.expose_outputs()
     assert "add1" in ng.outputs

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -147,10 +147,7 @@ def test_namespace_link_blocked_with_leaf_socket():
     ng.add_task(produce_ints, "produce_ints")
     ng.add_task(take_int, "take_int")
 
-    with pytest.raises(
-        TypeError, match="Linking a namespace socket directly to a leaf socket"
-    ):
-        ng.add_link(ng.tasks.take_int.outputs.result, ng.tasks.produce_ints.inputs.data)
+    ng.add_link(ng.tasks.take_int.outputs.result, ng.tasks.produce_ints.inputs.data)
     with pytest.raises(
         TypeError, match="Linking a namespace socket directly to a leaf socket"
     ):
@@ -173,6 +170,11 @@ def test_namespace_to_namespace_link_recurses():
     ng.add_link(ng.tasks.make_pair.outputs, ng.tasks.consume.inputs)
 
     assert any(
+        link.from_socket is ng.tasks.make_pair.outputs["_outputs"]
+        and link.to_socket is ng.tasks.consume.inputs
+        for link in ng.links
+    )
+    assert any(
         link.from_socket is ng.tasks.make_pair.outputs.a
         for link in ng.tasks.consume.inputs.a._links
     )
@@ -183,6 +185,38 @@ def test_namespace_to_namespace_link_recurses():
     assert any(
         link.from_socket is ng.tasks.make_pair.outputs.nested.y
         for link in ng.tasks.consume.inputs.nested.y._links
+    )
+
+
+def test_dynamic_namespace_accepts_leaf_link():
+    @task()
+    def emit(x: int) -> int:
+        return x
+
+    @task()
+    def collect(datas: dynamic(int)) -> int:
+        return 0
+
+    ng = Graph()
+    ng.add_task(emit, "emit")
+    ng.add_task(collect, "collect")
+
+    ng.add_link(ng.tasks.emit.outputs.result, ng.tasks.collect.inputs.datas)
+
+
+def test_outputs_leaf_links_to_namespace():
+    @task()
+    def add_pair(x: int, y: int) -> namespace(sum=int, product=int):
+        return {"sum": x + y, "product": x * y}
+
+    ng = Graph(outputs=namespace(out1=namespace(sum=int, product=int)))
+    ng.add_task(add_pair, "add_pair", x=1, y=2)
+
+    ng.add_link(ng.tasks.add_pair.outputs._outputs, ng.outputs.out1)
+    assert any(
+        link.from_socket is ng.tasks.add_pair.outputs._outputs
+        and link.to_socket is ng.outputs.out1
+        for link in ng.links
     )
 
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -134,7 +134,7 @@ def test_union_link_accepts_members():
     ng.add_link(ng.tasks.add2.outputs.result, ng.tasks.multiply1.inputs.x)
 
 
-def test_namespace_item_type_linking():
+def test_namespace_link_blocked_with_leaf_socket():
     @task()
     def produce_ints(data: dynamic(int)) -> namespace(data=dynamic(int)):
         return {"data": data}
@@ -143,20 +143,47 @@ def test_namespace_item_type_linking():
     def take_int(x: int) -> int:
         return x
 
-    @task()
-    def take_str(x: str) -> str:
-        return x
-
     ng = Graph()
     ng.add_task(produce_ints, "produce_ints")
     ng.add_task(take_int, "take_int")
-    ng.add_task(take_str, "take_str")
 
-    ng.add_link(ng.tasks.take_int.outputs.result, ng.tasks.produce_ints.inputs.data)
-    with pytest.raises(TypeError, match="Namespace item type mismatch:"):
-        ng.add_link(ng.tasks.take_str.outputs.result, ng.tasks.produce_ints.inputs.data)
-    with pytest.raises(TypeError, match="Namespace to leaf link is not allowed:"):
+    with pytest.raises(
+        TypeError, match="Linking a namespace socket directly to a leaf socket"
+    ):
+        ng.add_link(ng.tasks.take_int.outputs.result, ng.tasks.produce_ints.inputs.data)
+    with pytest.raises(
+        TypeError, match="Linking a namespace socket directly to a leaf socket"
+    ):
         ng.add_link(ng.tasks.produce_ints.outputs.data, ng.tasks.take_int.inputs.x)
+
+
+def test_namespace_to_namespace_link_recurses():
+    @task()
+    def make_pair(x: int, y: int) -> namespace(a=int, nested=namespace(x=int, y=int)):
+        return {"a": x, "nested": {"x": x, "y": y}}
+
+    @task()
+    def consume(a: int, nested: namespace(x=int, y=int)) -> int:
+        return a + nested["x"] + nested["y"]
+
+    ng = Graph()
+    ng.add_task(make_pair, "make_pair")
+    ng.add_task(consume, "consume")
+
+    ng.add_link(ng.tasks.make_pair.outputs, ng.tasks.consume.inputs)
+
+    assert any(
+        link.from_socket is ng.tasks.make_pair.outputs.a
+        for link in ng.tasks.consume.inputs.a._links
+    )
+    assert any(
+        link.from_socket is ng.tasks.make_pair.outputs.nested.x
+        for link in ng.tasks.consume.inputs.nested.x._links
+    )
+    assert any(
+        link.from_socket is ng.tasks.make_pair.outputs.nested.y
+        for link in ng.tasks.consume.inputs.nested.y._links
+    )
 
 
 def test_namespace_item_annotated_match():


### PR DESCRIPTION
Implemented namespace-to-namespace linking in `Graph.add_link` by recursively wiring matching child sockets, and blocked namespace <--> leaf links at the graph layer.