### PR TITLE
Fix TaggedValue Iterable masquerade and Enum serialization roundtrip

### DIFF
--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -446,6 +446,27 @@ _RUNTIME_EXTRA_KEYS = {
 
 
 class TaggedValue(wrapt.ObjectProxy):
+    # ``wrapt.ObjectProxy`` forwards every dunder to the wrapped value, including
+    # ``__iter__``, which is a method *slot* at the C level — so it is always
+    # present in ``ObjectProxy.__dict__`` regardless of what is wrapped. That
+    # makes ``isinstance(TaggedValue(1.5), collections.abc.Iterable)`` return
+    # True even though actually iterating raises TypeError, because
+    # ``Iterable.__subclasshook__`` only asks "does the class have ``__iter__``".
+    #
+    # To make the ABC check honest we dispatch to a subclass based on whether
+    # the wrapped value really is iterable. ``_TaggedScalar`` shadows
+    # ``__iter__`` with ``None``; Python's ``_check_methods`` treats that as
+    # "this method is intentionally unset", so the subclass hook returns
+    # ``NotImplemented`` and ``isinstance`` falls back to False — which is the
+    # right answer for a wrapped float / int / bool.
+    def __new__(cls, wrapped, socket=None):
+        if cls is TaggedValue:
+            from collections.abc import Iterable as _Iterable
+
+            target = _TaggedIterable if isinstance(wrapped, _Iterable) else _TaggedScalar
+            return super().__new__(target)
+        return super().__new__(cls)
+
     def __init__(self, wrapped, socket=None):
         super().__init__(wrapped)
 
@@ -495,6 +516,19 @@ class TaggedValue(wrapt.ObjectProxy):
 
     def __repr__(self):
         return f"TaggedValue({self.__wrapped__!r}, socket={self._socket!r}, uuid={self._uuid})"
+
+
+class _TaggedScalar(TaggedValue):
+    """Wrapper for non-iterable values. Shadows ``__iter__`` so the
+    ``collections.abc.Iterable`` subclass hook returns NotImplemented and
+    ``isinstance(..., Iterable)`` correctly reports False."""
+
+    __iter__ = None
+
+
+class _TaggedIterable(TaggedValue):
+    """Wrapper for iterable values. Inherits ObjectProxy's delegating
+    ``__iter__`` so iteration forwards to the wrapped object."""
 
 
 class BaseSocket:

--- a/src/node_graph/socket.py
+++ b/src/node_graph/socket.py
@@ -446,19 +446,9 @@ _RUNTIME_EXTRA_KEYS = {
 
 
 class TaggedValue(wrapt.ObjectProxy):
-    # ``wrapt.ObjectProxy`` forwards every dunder to the wrapped value, including
-    # ``__iter__``, which is a method *slot* at the C level — so it is always
-    # present in ``ObjectProxy.__dict__`` regardless of what is wrapped. That
-    # makes ``isinstance(TaggedValue(1.5), collections.abc.Iterable)`` return
-    # True even though actually iterating raises TypeError, because
-    # ``Iterable.__subclasshook__`` only asks "does the class have ``__iter__``".
-    #
-    # To make the ABC check honest we dispatch to a subclass based on whether
-    # the wrapped value really is iterable. ``_TaggedScalar`` shadows
-    # ``__iter__`` with ``None``; Python's ``_check_methods`` treats that as
-    # "this method is intentionally unset", so the subclass hook returns
-    # ``NotImplemented`` and ``isinstance`` falls back to False — which is the
-    # right answer for a wrapped float / int / bool.
+    # ObjectProxy always exposes __iter__ at the C level, so isinstance(
+    # TaggedValue(1.5), Iterable) would wrongly be True. Dispatch to a subclass
+    # that shadows __iter__ when the wrapped value isn't iterable.
     def __new__(cls, wrapped, socket=None):
         if cls is TaggedValue:
             from collections.abc import Iterable as _Iterable
@@ -519,16 +509,14 @@ class TaggedValue(wrapt.ObjectProxy):
 
 
 class _TaggedScalar(TaggedValue):
-    """Wrapper for non-iterable values. Shadows ``__iter__`` so the
-    ``collections.abc.Iterable`` subclass hook returns NotImplemented and
-    ``isinstance(..., Iterable)`` correctly reports False."""
+    """TaggedValue wrapping a non-iterable. Setting ``__iter__ = None`` makes
+    the ``Iterable`` ABC subclass hook return False for this proxy."""
 
     __iter__ = None
 
 
 class _TaggedIterable(TaggedValue):
-    """Wrapper for iterable values. Inherits ObjectProxy's delegating
-    ``__iter__`` so iteration forwards to the wrapped object."""
+    """TaggedValue wrapping an iterable; iteration is forwarded by ObjectProxy."""
 
 
 class BaseSocket:

--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -13,7 +13,7 @@ import inspect
 from copy import deepcopy
 from node_graph.orm.mapping import type_mapping as DEFAULT_TM
 from node_graph.socket_meta import CallRole, SocketMeta, merge_meta
-from node_graph.utils.struct_utils import structured_type_info
+from node_graph.utils.struct_utils import is_enum_type, structured_type_info
 from .socket import TaskSocketNamespace
 import ast
 import textwrap
@@ -1047,7 +1047,11 @@ class SocketSpecAPI:
                 _is_struct_model_type(base_T)
                 and _annot_is_leaf_marker(T) is None
                 and not _struct_is_leaf(base_T)
-            ):
+            ) or is_enum_type(base_T):
+                # Enums are leaves (no field expansion) but need the same
+                # ``structured_type`` extras so ``coerce_inputs_from_spec``
+                # can reconstruct the member after a process boundary has
+                # serialized it down to its bare value.
                 info = structured_type_info(base_T)
                 if info is not None and "structured_type" not in spec.meta.extras:
                     spec = replace(

--- a/src/node_graph/socket_spec.py
+++ b/src/node_graph/socket_spec.py
@@ -1048,10 +1048,8 @@ class SocketSpecAPI:
                 and _annot_is_leaf_marker(T) is None
                 and not _struct_is_leaf(base_T)
             ) or is_enum_type(base_T):
-                # Enums are leaves (no field expansion) but need the same
-                # ``structured_type`` extras so ``coerce_inputs_from_spec``
-                # can reconstruct the member after a process boundary has
-                # serialized it down to its bare value.
+                # Enums are leaves but still need structured_type extras so
+                # coerce_inputs_from_spec can rebuild the member after serialization.
                 info = structured_type_info(base_T)
                 if info is not None and "structured_type" not in spec.meta.extras:
                     spec = replace(

--- a/src/node_graph/utils/graph.py
+++ b/src/node_graph/utils/graph.py
@@ -135,18 +135,9 @@ def _assign_graph_outputs(outputs: Any, graph: Graph) -> None:
 
 
 def _deserialize_inputs(namespace: Any, values: Any, adapter: Any) -> Any:
-    """Walk a socket namespace and values dict in parallel, deserializing leaves.
-
-    For each leaf socket in ``namespace``, applies
-    ``adapter.deserialize(value, socket)`` to the corresponding value. Nested
-    namespaces recurse. This is the symmetric counterpart to the
-    serialize-on-write path: a ``@task.graph`` body whose signature declares
-    a primitive type should receive a primitive, even if the stored value
-    round-tripped through an AiiDA ``BaseType`` node for provenance.
-
-    Graphs without a serialization adapter (plain ``node_graph``) get a
-    no-op; the base ``SerializationAdapter.deserialize`` is identity.
-    """
+    """Recursively apply ``adapter.deserialize`` to leaves of ``values`` so a
+    ``@task.graph`` body receives the primitive its signature declares, even
+    when the stored value was wrapped by the engine for provenance."""
     from node_graph.socket import TaskSocketNamespace
 
     if adapter is None or not hasattr(adapter, "deserialize"):

--- a/src/node_graph/utils/graph.py
+++ b/src/node_graph/utils/graph.py
@@ -134,6 +134,38 @@ def _assign_graph_outputs(outputs: Any, graph: Graph) -> None:
         )
 
 
+def _deserialize_inputs(namespace: Any, values: Any, adapter: Any) -> Any:
+    """Walk a socket namespace and values dict in parallel, deserializing leaves.
+
+    For each leaf socket in ``namespace``, applies
+    ``adapter.deserialize(value, socket)`` to the corresponding value. Nested
+    namespaces recurse. This is the symmetric counterpart to the
+    serialize-on-write path: a ``@task.graph`` body whose signature declares
+    a primitive type should receive a primitive, even if the stored value
+    round-tripped through an AiiDA ``BaseType`` node for provenance.
+
+    Graphs without a serialization adapter (plain ``node_graph``) get a
+    no-op; the base ``SerializationAdapter.deserialize`` is identity.
+    """
+    from node_graph.socket import TaskSocketNamespace
+
+    if adapter is None or not hasattr(adapter, "deserialize"):
+        return values
+    if not isinstance(values, dict):
+        return values
+    out = dict(values)
+    for name, item in namespace._sockets.items():
+        if name not in out:
+            continue
+        value = out[name]
+        if isinstance(item, TaskSocketNamespace):
+            if isinstance(value, dict):
+                out[name] = _deserialize_inputs(item, value, adapter)
+        else:
+            out[name] = adapter.deserialize(value, item)
+    return out
+
+
 def materialize_graph(
     func: Callable,
     in_spec: SocketSpec,
@@ -173,6 +205,9 @@ def materialize_graph(
         tag_socket_value(graph.inputs)
         inputs = graph.inputs._collect_values(unwrap=False)
         inputs = coerce_inputs_from_spec(inputs, in_spec)
+        inputs = _deserialize_inputs(
+            graph.inputs, inputs, getattr(graph, "serialization", None)
+        )
         raw = func(**inputs)
         _assign_graph_outputs(raw, graph)
         tag_socket_value(graph.inputs, only_uuid=True)

--- a/src/node_graph/utils/struct_utils.py
+++ b/src/node_graph/utils/struct_utils.py
@@ -35,13 +35,7 @@ def structured_to_dict(value: Any) -> Any:
 
 
 def structured_type_info(tp: Any) -> Dict[str, str] | None:
-    """Return a serializable descriptor for structured types.
-
-    ``Enum`` subclasses are treated as structured leaves: the descriptor lets
-    ``coerce_structured_value`` rebuild the member from its serialized value
-    (``str``-Enum, ``int``-Enum, etc.) after a process boundary has flattened
-    it.
-    """
+    """Return a serializable descriptor for structured types (incl. ``Enum``)."""
     if is_dataclass(tp):
         return {"kind": "dataclass", "path": structured_type_path(tp)}
     if isinstance(tp, type) and issubclass(tp, BaseModel):
@@ -65,15 +59,12 @@ def import_structured_type(path: str) -> Any:
 
 
 def coerce_structured_value(value: Any, info: Dict[str, str] | None) -> Any:
-    """Rebuild a structured instance from a flat value when spec says so.
-
-    ``Enum`` is handled before the dict-only gate because its serialized form
-    is the bare member value (``str``, ``int``, ...), not a dict.
-    """
+    """Rebuild a structured instance from a flat value when spec says so."""
     if info is None:
         return value
     cls = import_structured_type(info["path"])
     kind = info.get("kind")
+    # Enum check goes before the dict gate: its serialized form is a bare value.
     if kind == "enum":
         if isinstance(value, cls):
             return value

--- a/src/node_graph/utils/struct_utils.py
+++ b/src/node_graph/utils/struct_utils.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
+from enum import Enum
 from typing import Any, Dict
 import importlib
 
 from pydantic import BaseModel
+
+
+def is_enum_type(tp: Any) -> bool:
+    """Return True for Enum subclasses (including ``str``- and ``int``-Enum)."""
+    return isinstance(tp, type) and issubclass(tp, Enum)
 
 
 def is_structured_instance(value: Any) -> bool:
@@ -29,11 +35,19 @@ def structured_to_dict(value: Any) -> Any:
 
 
 def structured_type_info(tp: Any) -> Dict[str, str] | None:
-    """Return a serializable descriptor for structured types."""
+    """Return a serializable descriptor for structured types.
+
+    ``Enum`` subclasses are treated as structured leaves: the descriptor lets
+    ``coerce_structured_value`` rebuild the member from its serialized value
+    (``str``-Enum, ``int``-Enum, etc.) after a process boundary has flattened
+    it.
+    """
     if is_dataclass(tp):
         return {"kind": "dataclass", "path": structured_type_path(tp)}
     if isinstance(tp, type) and issubclass(tp, BaseModel):
         return {"kind": "pydantic", "path": structured_type_path(tp)}
+    if is_enum_type(tp):
+        return {"kind": "enum", "path": structured_type_path(tp)}
     return None
 
 
@@ -51,15 +65,23 @@ def import_structured_type(path: str) -> Any:
 
 
 def coerce_structured_value(value: Any, info: Dict[str, str] | None) -> Any:
-    """Rebuild a structured instance from a dict when spec says so."""
+    """Rebuild a structured instance from a flat value when spec says so.
+
+    ``Enum`` is handled before the dict-only gate because its serialized form
+    is the bare member value (``str``, ``int``, ...), not a dict.
+    """
     if info is None:
         return value
+    cls = import_structured_type(info["path"])
+    kind = info.get("kind")
+    if kind == "enum":
+        if isinstance(value, cls):
+            return value
+        return cls(value)
     if is_structured_instance(value):
         return value
     if not isinstance(value, dict):
         return value
-    cls = import_structured_type(info["path"])
-    kind = info.get("kind")
     if kind == "pydantic":
         if contains_tagged_value(value):
             if hasattr(cls, "model_construct"):

--- a/tests/test_engine_local.py
+++ b/tests/test_engine_local.py
@@ -224,9 +224,6 @@ class Color(str, Enum):
 
 @task(outputs=ns(name=str))
 def color_name(color: Color) -> dict:
-    # Without enum coercion ``color`` would arrive as a plain string and
-    # ``color.name`` would resolve to ``str.name`` (an attribute lookup
-    # surprise), so this asserts the spec rebuilt the member.
     assert isinstance(color, Color), f"expected Color, got {type(color).__name__}"
     return {"name": color.name}
 

--- a/tests/test_engine_local.py
+++ b/tests/test_engine_local.py
@@ -7,6 +7,7 @@ from node_graph.engine.local import LocalEngine
 from node_graph.engine.provenance import ProvenanceRecorder
 from typing import Annotated, Any
 from dataclasses import dataclass
+from enum import Enum
 from pydantic import BaseModel
 
 
@@ -213,3 +214,28 @@ def test_local_engine_accepts_dataclass_models():
 
     assert results["sum"] == 7
     assert results["product"] == 12
+
+
+class Color(str, Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+@task(outputs=ns(name=str))
+def color_name(color: Color) -> dict:
+    # Without enum coercion ``color`` would arrive as a plain string and
+    # ``color.name`` would resolve to ``str.name`` (an attribute lookup
+    # surprise), so this asserts the spec rebuilt the member.
+    assert isinstance(color, Color), f"expected Color, got {type(color).__name__}"
+    return {"name": color.name}
+
+
+def test_local_engine_coerces_str_enum():
+    ng = Graph(name="local-enum", outputs=ns(name=str))
+    node = ng.add_task(color_name, "pick", color=Color.GREEN)
+    ng.add_link(node.outputs.name, ng.outputs.name)
+
+    results = LocalEngine().run(ng)
+
+    assert results["name"] == "GREEN"


### PR DESCRIPTION
## Summary

Two related fixes to value handling across process boundaries, plus the symmetric deserialize hook for `materialize_graph`.

### `TaggedValue` Iterable masquerade (`src/node_graph/socket.py`)
`isinstance(TaggedValue(1.5), Iterable)` was wrongly `True` — even though actually iterating raised `TypeError`. `TaggedValue.__new__` now dispatches to one of two private subclasses based on whether the wrapped value is iterable:
- `_TaggedScalar` shadows `__iter__ = None`, which makes the `Iterable` ABC subclass hook return `False`.
- `_TaggedIterable` keeps ObjectProxy's forwarding behavior.

### Enum serialization roundtrip
Enums (incl. `str`-Enum / `int`-Enum) are now treated as structured leaves so they survive a process boundary:
- `src/node_graph/utils/struct_utils.py`: `structured_type_info` recognizes `Enum`; `coerce_structured_value` rebuilds the member from its bare serialized value
- `src/node_graph/socket_spec.py`: the spec attaches `structured_type` extras to enum sockets so `coerce_inputs_from_spec` can reconstruct the member.

### Deserialize hook in `materialize_graph` (`src/node_graph/utils/graph.py`)
New `_deserialize_inputs` walks the input namespace and applies `adapter.deserialize` to each leaf before the graph body runs. Symmetric counterpart to the existing serialize-on-write path: a `@task.graph` body whose signature declares a primitive should receive a primitive even if the engine wrapped it for provenance.
